### PR TITLE
Fixed print bug regarding newlines

### DIFF
--- a/src/ir/AST/Desugarer.hs
+++ b/src/ir/AST/Desugarer.hs
@@ -30,6 +30,9 @@ desugar FunctionCall{emeta, name = Name "exit", args} = Exit emeta args
 desugar FunctionCall{emeta, name = Name "print", args = (string@(StringLiteral {stringLit = s})):args} = 
     Print emeta s args
 
+desugar FunctionCall{emeta, name = Name "print", args = [e]} = 
+    Print emeta "{}\n" [e]
+
 desugar fCall@FunctionCall{emeta, name = Name "assertTrue", args = [cond]} = 
     IfThenElse emeta cond
            (Skip (cloneMeta emeta))

--- a/src/parser/Parser/Parser.hs
+++ b/src/parser/Parser/Parser.hs
@@ -325,8 +325,8 @@ expr :: Parser Expr
 expr  =  unit
      <|> try embed
      <|> try path
-     <|> try print
      <|> try functionCall
+     <|> try print
      <|> closure
      <|> parens expression
      <|> varAccess


### PR DESCRIPTION
```
print "foo" -- has a newline
print("foo") -- has no newline (this is the fix)
```

Before, `print("foo")` and `print("foo{}", "")` printed different
things (newline resp. no newline).
