### PR TITLE
creates a virtual environment for encorec

### DIFF
--- a/activate
+++ b/activate
@@ -1,0 +1,76 @@
+# This file must be used with "source bin/activate" *from bash*
+# you cannot run it directly
+
+deactivate () {
+    # reset old environment variables
+    if [ -n "$_OLD_VIRTUAL_PATH" ] ; then
+        PATH="$_OLD_VIRTUAL_PATH"
+        export PATH
+        unset _OLD_VIRTUAL_PATH
+    fi
+    if [ -n "$_OLD_VIRTUAL_ENCORECHOME" ] ; then
+        ENCORECHOME="$_OLD_VIRTUAL_ENCORECHOME"
+        export ENCORECHOME
+        unset _OLD_VIRTUAL_ENCORECHOME
+    fi
+
+    # This should detect bash and zsh, which have a hash command that must
+    # be called to get it to forget past commands.  Without forgetting
+    # past commands the $PATH changes we made may not be respected
+    if [ -n "$BASH" -o -n "$ZSH_VERSION" ] ; then
+        hash -r 2>/dev/null
+    fi
+
+    if [ -n "$_OLD_VIRTUAL_PS1" ] ; then
+        PS1="$_OLD_VIRTUAL_PS1"
+        export PS1
+        unset _OLD_VIRTUAL_PS1
+    fi
+
+    unset ENCOREC_VIRTUAL_ENV
+    if [ ! "$1" = "nondestructive" ] ; then
+    # Self destruct!
+        unset -f deactivate
+    fi
+}
+
+# unset irrelevant variables
+deactivate nondestructive
+
+ENCOREC_VIRTUAL_ENV=$(pwd)
+export ENCOREC_VIRTUAL_ENV
+
+_OLD_VIRTUAL_PATH="$PATH"
+PATH="$ENCOREC_VIRTUAL_ENV/release:$PATH"
+export PATH
+
+# unset ENCORECHOME if set
+# this will fail if ENCORECHOME is set to the empty string (which is bad anyway)
+# could use `if (set -u; : $ENCORECHOME) ;` in bash
+if [ -n "$ENCORECHOME" ] ; then
+    _OLD_VIRTUAL_ENCORECHOME="$ENCORECHOME"
+    unset ENCORECHOME
+fi
+
+if [ -z "$ENCOREC_VIRTUAL_ENV_DISABLE_PROMPT" ] ; then
+    _OLD_VIRTUAL_PS1="$PS1"
+    if [ "x" != x ] ; then
+        PS1="$PS1"
+    else
+    if [ "`basename \"$ENCOREC_VIRTUAL_ENV\"`" = "__" ] ; then
+        # special case for Aspen magic directories
+        # see http://www.zetadev.com/software/aspen/
+        PS1="[`basename \`dirname \"$ENCOREC_VIRTUAL_ENV\"\``] $PS1"
+    else
+        PS1="(`basename \"$ENCOREC_VIRTUAL_ENV\"`)$PS1"
+    fi
+    fi
+    export PS1
+fi
+
+# This should detect bash and zsh, which have a hash command that must
+# be called to get it to forget past commands.  Without forgetting
+# past commands the $PATH changes we made may not be respected
+if [ -n "$BASH" -o -n "$ZSH_VERSION" ] ; then
+    hash -r 2>/dev/null
+fi


### PR DESCRIPTION
the idea is to create a virtual environment similar to what you
can expect in `virtualenv` (python), `rbenv` (ruby), `cabal` (haskell). At the moment
it just sets the encore compiler to the right path. Therefore, forking
and having multiple copies of the repo with multiple compilers is
easy to handle. Steps involved:
1. go to the encore compiler fork you would like to activate
2. `source activate`
3. from this terminal, you can compile any encore program and
    it will safely use the encore compiler that you jut activated.

missing features:
- no real dependency management yet, so no need to create new folder

credits: virtualenv
