### PR TITLE
boyscout: clean up ootr example

### DIFF
--- a/experiments/threadring/ootr.enc
+++ b/experiments/threadring/ootr.enc
@@ -5,15 +5,14 @@ class Main
       first = new Agent(i)
       next = null : Agent
       n = 50*1000*1000
-      N = i + 503
-      i = i + 1
+      N = 503
       cur = first
     in {
       while (i < N) {
+        i = i + 1;
         next = new Agent(i);
         cur.setNext(next);
         cur = next;
-        i = i + 1;
       };
       cur.setNext(first);
       first.run(n);
@@ -34,10 +33,8 @@ class Agent
 
   def run(n : int): void {
     if (n > 0) then {
-      this.next!run(n-1);
-      ();
+      this.next ! run(n-1)
     } else {
-      print this.id;
-      ();
+      print(this.id)
     }
   }


### PR DESCRIPTION
clean up `ootr` example for the Brussels demo:
- do not return `()`, if something returns `void` it doesn't matter
  what is the last expression, it knows it has to return `void`
- remove re-definition of `i` to `i + 1`, we can do this inside
  the `while` loop
- remove `N = i + 503`
