### PR TITLE
Deleted a symbol that caused doc creation to fail

### DIFF
--- a/src/back/CCode/Main.hs
+++ b/src/back/CCode/Main.hs
@@ -72,7 +72,7 @@ data CCode a where
     Deref        :: UsableAs e Expr => CCode e -> CCode Expr
     Cast         :: UsableAs e Expr => CCode Ty -> CCode e -> CCode Expr
     ArrAcc       :: Int -> CCode Lval -> CCode Lval
-    Amp          :: (UsableAs e Expr) => CCode e -> CCode Expr -- | Ampersand
+    Amp          :: (UsableAs e Expr) => CCode e -> CCode Expr -- Ampersand
     Ptr          :: CCode Ty -> CCode Ty
     FunctionDecl :: CCode Ty -> CCode Name -> [CCode Ty] -> CCode Toplevel
     Function     :: CCode Ty -> CCode Name -> [CVarSpec] -> CCode Stat -> CCode Toplevel


### PR DESCRIPTION
When running `make doc`, it fails with the following:

```
[...]
cabal haddock --all
Running Haddock for mylittlepony-0.1.0.0...
Preprocessing executable 'encorec' for mylittlepony-0.1.0.0...
Haddock coverage:
  50% (  1 /  2) in 'CodeGen.Typeclasses'
  50% (  3 /  6) in 'Identifiers'
   2% (  1 / 50) in 'Types'
   0% (  0 / 13) in 'AST.Meta'
   4% (  1 / 26) in 'AST.AST'
  14% (  1 /  7) in 'AST.PrettyPrinter'
  22% (  2 /  9) in 'AST.Util'
   0% (  0 /  2) in 'AST.Desugarer'
   0% (  0 /  2) in 'Optimizer.Optimizer'
   0% (  0 /  2) in 'CodeGen.Preprocessor'

src/back/CCode/Main.hs:75:64: parse error on input ‘-- | Ampersand’
make: *** [doc] Error 1
```

This pull request fixes this problem and allows to correctly build the documentation.
