### PR TITLE
Add eager and lazy future support.

### DIFF
--- a/src/runtime/future/future.c
+++ b/src/runtime/future/future.c
@@ -120,8 +120,6 @@ void future_trace(void* p)
   /// concurrent access should not be a problem.
   perr("future_trace");
 
-  pony_trace(p);
-
   future_t* fut = (future_t*)p;
 
   if (future_fulfilled(fut)) {
@@ -301,10 +299,11 @@ void future_block_actor(future_t *fut)
   pony_unschedule(a);
   assert(fut->no_responsibilities < 16);
   fut->responsibilities[fut->no_responsibilities++] = (actor_entry_t) { .type = BLOCKED_MESSAGE, .message = (message_entry_t) { .actor = a } };
-  UNBLOCK;
 
-  actor_block((encore_actor_t*)a);
+  encore_actor_t *actor = (encore_actor_t*) a;
 
+  actor->lock = &fut->lock;
+  actor_block(actor);
 }
 
 // ===============================================================

--- a/src/runtime/pony/src/actor/actor.c
+++ b/src/runtime/pony/src/actor/actor.c
@@ -134,8 +134,8 @@ bool actor_run(pony_actor_t* actor)
   this_actor = actor;
 
   if (!has_flag(actor, FLAG_SYSTEM)) {
-    if (!encore_actor_run_hook((encore_actor_t *)actor)) {
-      return false;
+    if (encore_actor_run_hook((encore_actor_t *)actor)) {
+      return !has_flag((pony_actor_t *)actor, FLAG_UNSCHEDULED);
     }
   }
 
@@ -254,16 +254,6 @@ pony_actor_t* actor_next(pony_actor_t* actor)
 void actor_setnext(pony_actor_t* actor, pony_actor_t* next)
 {
   actor->next = next;
-}
-
-pony_actor_t* actor_dormant_next(pony_actor_t* actor)
-{
-  return actor->dormant_next;
-}
-
-void actor_set_dormant_next(pony_actor_t* actor, pony_actor_t* dormant_next)
-{
-  actor->dormant_next = dormant_next;
 }
 
 void actor_inc_rc()


### PR DESCRIPTION
It seems that thread local variables are not updated properly on mac,
which might be a [bug](https://llvm.org/bugs/show_bug.cgi?id=23154),
filed anyway.

Currently, on mac, only one OS thread is used.

Test result on my box (Linux):
     Tests passed: 53/58
     Tests failed: 5/58
         await
         deadlock_yourself
         parametricClasses
         parametricPrint
         suspend
