### PR TITLE
Fixed error for using textual operators such as "not","and" and "or"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ src/tests/encore/basic/*
 src/tests/encore/modules/*
 !src/tests/encore/modules/*.enc
 !src/tests/encore/modules/*.out
+/.dist-buildwrapper/
+.project

--- a/src/parser/Parser/Parser.hs
+++ b/src/parser/Parser/Parser.hs
@@ -233,16 +233,25 @@ expression = buildExpressionParser opTable expr
     where
       opTable = [
                  [arrayAccess],
-                 [prefix "not" Identifiers.NOT],
+                 [textualPrefix "not" Identifiers.NOT],
+                 [textualOperator "and" Identifiers.AND, textualOperator "or" Identifiers.OR],
                  [op "*" TIMES, op "/" DIV, op "%" MOD],
                  [op "+" PLUS, op "-" MINUS],
                  [op "<" Identifiers.LT, op ">" Identifiers.GT, op "<=" Identifiers.LTE, op ">=" Identifiers.GTE, op "==" Identifiers.EQ, op "!=" NEQ],
-                 [op "and" Identifiers.AND, op "or" Identifiers.OR],
                  [messageSend],
                  [typedExpression],
                  [chain],
                  [assignment]
                 ]
+                
+      textualPrefix s operator = 
+          Prefix (try(do pos <- getPosition
+                         reserved s
+                         return (\x -> Unary (meta pos) operator x)))   
+      textualOperator s binop = 
+          Infix (try(do pos <- getPosition
+                        reserved s
+                        return (\e1 e2 -> Binop (meta pos) binop e1 e2))) AssocLeft
       prefix s operator = 
           Prefix (do pos <- getPosition
                      reservedOp s

--- a/src/tests/encore/basic/prefix_test.enc
+++ b/src/tests/encore/basic/prefix_test.enc
@@ -1,0 +1,14 @@
+class Main
+    def main() : void
+        let
+            nothing = "blingbling"
+            ping = true
+            anders = true
+        in{
+            print(nothing);
+            print(not(ping));
+            print(not     ping);
+            print(not anders);
+            print(ping and anders);
+         }
+        

--- a/src/tests/encore/basic/prefix_test.out
+++ b/src/tests/encore/basic/prefix_test.out
@@ -1,0 +1,5 @@
+blingbling
+bool<0>
+bool<0>
+bool<0>
+bool<1>


### PR DESCRIPTION
Se issue [115](https://github.com/parapluu/encore/issues/115)
