### PR TITLE
change name of global functions, fixes #94

### DIFF
--- a/src/back/CodeGen/CCodeNames.hs
+++ b/src/back/CodeGen/CCodeNames.hs
@@ -88,7 +88,7 @@ method_impl_name clazz mname =
 
 global_closure_name :: ID.Name -> CCode Name
 global_closure_name funname =
-    Nam $ (show funname)
+    Nam $ "_encore__global_closure_" ++ (show funname)
 
 global_function_name :: ID.Name -> CCode Name
 global_function_name funname =


### PR DESCRIPTION
Change the name of the global functions. this avoids clashes with the
host language by renaming the global functions.

e.g. i can name a global function `malloc` and there won't be any conflict
at the C level.
