### PR TITLE
Support for bundle keyword

### DIFF
--- a/bundles/prototype/Proto/Id.enc
+++ b/bundles/prototype/Proto/Id.enc
@@ -1,5 +1,5 @@
 
--- module Proto.Id where
+bundle Proto.Id where
 
 def id(x: string): string 
     x

--- a/doc/encore/lang/syntax/grammar.scrbl
+++ b/doc/encore/lang/syntax/grammar.scrbl
@@ -56,6 +56,8 @@ This section introduces the Encore grammar by using the BNF-grammar notation and
 @(encore/keyword def)
 @(encore/keyword embed)
 @(encore/keyword import)
+@(encore/keyword where)
+@(encore/keyword bundle)
 @(encore/keyword as)
 @(encore/keyword class)
 @(encore/keyword print)
@@ -82,6 +84,7 @@ This section introduces the Encore grammar by using the BNF-grammar notation and
 
 @; Non-terminals
 @(encore/nonterm Program)
+@(encore/nonterm BundleDecl)
 @(encore/nonterm Imports)
 @(encore/nonterm EmbedTL)
 @(encore/nonterm ClassDecl)
@@ -120,10 +123,17 @@ This section introduces the Encore grammar by using the BNF-grammar notation and
      @BNF[(list Program
     		@alt[
 		  @seq[
+			@optional[BundleDecl]
 			@kleenestar[Imports]
 			@optional[EmbedTL]
 		  	@nonterm{ClassDecl}]
 		eps])
+
+      (list BundleDecl
+         @seq[bundle QName where])
+
+	  (list ClassDecl
+	  	@seq[@(optional passive) class  Name open-c FieldDecls MethodDecls close-c])
 
           (list Imports
                 @seq[import

--- a/doc/encore/lang/syntax/syntax.scrbl
+++ b/doc/encore/lang/syntax/syntax.scrbl
@@ -17,12 +17,17 @@ Here follows a trivial example of usage of the module system.
 
 File  @code{Lib.enc}:
 @codeblock|{
+  bundle Lib where
+
   class Foo:
     def boo():void {
 		print "^-^"
     }
   
 }|
+
+Line @code{bundle Lib where} declares the module name. This line is optional, though desirable 
+for library code. 
 
 File  @code{Bar.enc}:
 @codeblock|{
@@ -44,7 +49,7 @@ Here the file @code{Bar.enc} imports @code{Lib.enc} and can thus access the clas
 To import files from different directories one needs to use the @code{-I path} argument for the compiler.
 
 Modules are hierarchical. Module @code{A.B.C} (in some directory @code{A/B/C.enc}
-in the include path) can be imported using @code{import A.B.C}.
+in the include path) is declared using @code{bundle A.B.C where}  and  imported using @code{import A.B.C}.
 
 As of now the module system has no notion of name spaces so all imported objects needs to have unique names.
 There is also no support for cyclic imports and no "include guards" so it's up to the programmer 

--- a/src/front/ModuleExpander.hs
+++ b/src/front/ModuleExpander.hs
@@ -18,9 +18,9 @@ tosrc dir target = dir ++ tosrc' target
 expandModules :: [FilePath] -> Program -> IO Program
 expandModules importDirs p = expandProgram p
     where
-      expandProgram p@(Program etl imps funs cls) =
+      expandProgram p@(Program bundle etl imps funs cls) =
           do exImps <- mapM expandImport imps
-             return $ Program etl exImps funs cls
+             return $ Program bundle etl exImps funs cls
              
       expandImport i@(Import meta target) = 
           do (imp, src) <- importOne i

--- a/src/front/TopLevel.hs
+++ b/src/front/TopLevel.hs
@@ -20,9 +20,7 @@ import Data.List
 import Data.List.Utils(split)
 import Control.Monad
 import SystemUtils
-
-import System.IO.Unsafe -- for TH hackery
-import Language.Haskell.TH -- for TH hackery
+import Language.Haskell.TH -- for Template Haskell hackery
 
 import Makefile
 import Utils
@@ -40,6 +38,7 @@ import CodeGen.Preprocessor
 import CodeGen.Header
 import CCode.PrettyCCode
 
+-- the following line of code resolves the standard path at compile time using Template Haskell
 standardLibLocation = $((stringE . init) =<< (runIO $ System.Environment.getEnv "ENCORE_BUNDLES" ))
 
 data Phase = Parsed | TypeChecked

--- a/src/ir/AST/AST.hs
+++ b/src/ir/AST/AST.hs
@@ -17,7 +17,8 @@ import Identifiers
 import Types
 import AST.Meta hiding(Closure)
 
-data Program = Program {etl :: EmbedTL, 
+data Program = Program {bundle :: BundleDecl, 
+                        etl :: EmbedTL, 
                         imports :: [ImportDecl], 
                         functions :: [Function], 
                         classes :: [ClassDecl]} deriving(Show)
@@ -48,7 +49,12 @@ class HasMeta a where
 
 data EmbedTL = EmbedTL {etlmeta   :: Meta EmbedTL,
                         etlheader :: String,
-                        etlbody   :: String} deriving (Show)
+                        etlbody   :: String } deriving (Show)
+
+data BundleDecl = Bundle { bmeta :: Meta BundleDecl,
+                           bname :: QName } 
+                | NoBundle 
+                deriving Show
 
 data ImportDecl = Import {imeta   :: Meta ImportDecl,
                           itarget :: QName } 

--- a/src/ir/AST/PrettyPrinter.hs
+++ b/src/ir/AST/PrettyPrinter.hs
@@ -69,11 +69,16 @@ ppType :: Type -> Doc
 ppType = text . show
 
 ppProgram :: Program -> Doc
-ppProgram (Program (EmbedTL _ header code) importDecls functions classDecls) = 
-    text "embed" $+$ text header $+$ text "body" $+$ text code $+$ text "end" $+$
+ppProgram (Program bundle (EmbedTL _ header code) importDecls functions classDecls) = 
+    ppBundleDecl bundle $+$
+         text "embed" $+$ text header $+$ text "body" $+$ text code $+$ text "end" $+$
          vcat (map ppImportDecl importDecls) $+$
          vcat (map ppFunction functions) $+$
          vcat (map ppClassDecl classDecls)
+
+ppBundleDecl :: BundleDecl -> Doc
+ppBundleDecl NoBundle = empty
+ppBundleDecl Bundle{bname} = text "bundle" <+> ppQName bname
 
 ppImportDecl :: ImportDecl -> Doc
 ppImportDecl Import {itarget} = text "import" <+> ppQName itarget

--- a/src/ir/AST/Util.hs
+++ b/src/ir/AST/Util.hs
@@ -77,7 +77,7 @@ foldr f acc e =
     in f e childResult
 
 foldrAll :: (Expr -> a -> a) -> a -> Program -> [[a]]
-foldrAll f e (Program _ _ funs classes) = [map (foldFunction f e) funs] ++ (map (foldClass f e) classes)
+foldrAll f e (Program _ _ _ funs classes) = [map (foldFunction f e) funs] ++ (map (foldClass f e) classes)
     where
       foldFunction f e (Function {funbody}) = foldr f e funbody
       foldClass f e (Class {methods}) = map (foldMethod f e) methods
@@ -94,7 +94,7 @@ extendAccum f acc0 e =
       f acc1 (putChildren childResults e)
 
 extendAccumProgram :: (acc -> Expr -> (acc, Expr)) -> acc -> Program -> (acc, Program)
-extendAccumProgram f acc0 (Program etl imps funs classes) = (acc2, Program etl imps funs' classes')
+extendAccumProgram f acc0 (Program bundle etl imps funs classes) = (acc2, Program bundle etl imps funs' classes')
     where 
       (acc1, funs') = List.mapAccumL (extendAccumFunction f) acc0 funs
       extendAccumFunction f acc fun@(Function{funbody}) = (acc', fun{funbody = funbody'})
@@ -113,7 +113,7 @@ filter :: (Expr -> Bool) -> Expr -> [Expr]
 filter cond = foldr (\e acc -> if cond e then e:acc else acc) []
 
 extractTypes :: Program -> [Type]
-extractTypes (Program _ _ funs classes) = 
+extractTypes (Program _ _ _ funs classes) = 
     List.nub $ concat $ concatMap extractFunctionTypes funs ++ concatMap extractClassTypes classes
     where
       extractFunctionTypes Function {funtype, funparams, funbody} = (typeComponents funtype) : (map extractParamTypes funparams) ++ [extractExprTypes funbody]

--- a/src/parser/Parser/Parser.hs
+++ b/src/parser/Parser/Parser.hs
@@ -42,8 +42,8 @@ lexer =
                P.reservedNames = ["passive", "class", "def", "stream", "breathe",
                                   "let", "in", "if", "unless", "then", "else", "repeat", "while", 
                                   "get", "yield", "eos", "getNext", "new", "this", "await", "suspend",
-				  "and", "or", "not", "true", "false", "null", "embed", "body", "end", 
-                                  "Fut", "Par", "Stream", "import", "qualified", "module", "peer"],
+				  "and", "or", "not", "true", "false", "null", "embed", "body", "end", "where", 
+                                  "Fut", "Par", "Stream", "import", "qualified", "bundle", "peer"],
                P.reservedOpNames = [":", "=", "==", "!=", "<", ">", "<=", ">=", "+", "-", "*", "/", "%", "->", "\\", "()", "~~>"]
              }
 
@@ -129,15 +129,24 @@ typ  =  try arrow
 program :: Parser Program
 program = do optional hashbang
              whiteSpace
+             bundle <- bundledecl
              importdecls <- many importdecl
              embedtl <- embedTL
              functions <- many function
              classes <- many classDecl
              eof
-             return $ Program embedtl importdecls functions classes
+             return $ Program bundle embedtl importdecls functions classes
     where
       hashbang = do string "#!"
                     many (noneOf "\n\r")
+
+bundledecl :: Parser BundleDecl
+bundledecl = option NoBundle $ do 
+  pos <- getPosition 
+  reserved "bundle"
+  bname <- longidentifier
+  reserved "where"
+  return $ Bundle (meta pos) bname
 
 importdecl :: Parser ImportDecl
 importdecl = do 

--- a/src/types/Typechecker/Typechecker.hs
+++ b/src/types/Typechecker/Typechecker.hs
@@ -35,7 +35,7 @@ typecheckEncoreProgram p =
        return prog
 
 typecheckProgram :: Program -> Either TCError (Program, Environment)
-typecheckProgram p@(Program etl imps funs cls) = 
+typecheckProgram p@(Program bundle etl imps funs cls) = 
     do -- check all imps, merge their environments, use that as basis of environment evn
        checkedImps <- mapM typecheckImport imps
        let (pImps, envs) = unzip checkedImps
@@ -44,7 +44,7 @@ typecheckProgram p@(Program etl imps funs cls) =
        res <- runReader (runExceptT (typecheck p)) bigenv
        return $ (patch res pImps, env)
    where
-       patch (Program etl imps funs cls) newimps = Program etl newimps funs cls
+       patch (Program bundle etl imps funs cls) newimps = Program bundle etl newimps funs cls
           
 typecheckImport (PulledImport meta qname src program) = 
     do
@@ -122,10 +122,10 @@ instance Checkable Program where
     --  E |- class1 .. E |- classm
     -- ----------------------------
     --  E |- funs classes
-    typecheck (Program etl imps funs classes) = 
+    typecheck (Program bundle etl imps funs classes) = 
         do efuns <- mapM pushTypecheck funs
            eclasses <- mapM pushTypecheck classes
-           return $ Program etl imps efuns eclasses
+           return $ Program bundle etl imps efuns eclasses
 
 instance Checkable Function where
    ---  |- funtype


### PR DESCRIPTION
This adds syntax support for the bundle keyword for declaring Encore modules.

Documentation and one test case provided.

No actual checking performed, as we are still working out the semantics.
