### PR TITLE
Made updating type fields in AST nodes explicit

### DIFF
--- a/src/back/CodeGen/Expr.hs
+++ b/src/back/CodeGen/Expr.hs
@@ -98,6 +98,8 @@ instance Translatable A.Expr (State Ctx.Context (CCode Lval, CCode Stat)) where
   translate lit@(A.RealLiteral {A.realLit = r}) = named_tmp_var "literal" (A.getType lit) (Double r)
   translate lit@(A.StringLiteral {A.stringLit = s}) = named_tmp_var "literal" (A.getType lit) (String s)
 
+  translate A.TypedExpr {A.body} = translate body
+
   translate unary@(A.Unary {A.op, A.operand}) = do
     (noperand, toperand) <- translate operand
     tmp <- Ctx.gen_named_sym "unary"

--- a/src/ir/AST/AST.hs
+++ b/src/ir/AST/AST.hs
@@ -274,10 +274,6 @@ instance HasMeta Expr where
                    where
                      ty' = AST.AST.getType x
 
-    setType ty' expr@(TypedExpr {ty}) = expr {emeta = AST.Meta.setType ty' (emeta expr), ty = ty'}
-    setType ty' expr@(New {ty}) = expr {emeta = AST.Meta.setType ty' (emeta expr), ty = ty'}
-    setType ty' expr@(Peer {ty}) = expr {emeta = AST.Meta.setType ty' (emeta expr), ty = ty'}
-    setType ty' expr@(Embed {ty}) = expr {emeta = AST.Meta.setType ty' (emeta expr), ty = ty'}
     setType ty expr = expr {emeta = AST.Meta.setType ty (emeta expr)}
 
 setSugared :: Expr -> Expr -> Expr


### PR DESCRIPTION
This PR fixes issue #154. It also makes `setType` in `AST.hs` less
clever in order to avoid similar bugs in the future (the problem was
that `setType` updated any type children to the AST-node, as well as the
meta information -- something that was easy to forget to add when
extending the language. This new version only updates the meta info
and moves the obligation to update types to the typechecker).

Also, there is now an explicit case in the back-end for typed
expressions (before the type-cast was thrown away after typechecking).
