### PR TITLE
Add pointer to runtime type in each object

### DIFF
--- a/src/back/CodeGen/CCodeNames.hs
+++ b/src/back/CodeGen/CCodeNames.hs
@@ -85,6 +85,9 @@ array = Ptr $ Typ "array_t"
 unit :: CCode Lval
 unit = Embed "UNIT"
 
+self_type_field :: CCode Name
+self_type_field = Nam "_enc__self_type"
+
 -- | each method is implemented as a function with a `this`
 -- pointer. This is the name of that function
 method_impl_name :: Ty.Type -> ID.Name -> CCode Name

--- a/src/back/CodeGen/Expr.hs
+++ b/src/back/CodeGen/Expr.hs
@@ -232,15 +232,16 @@ instance Translatable A.Expr (State Ctx.Context (CCode Lval, CCode Stat)) where
 
   translate (A.New {A.ty}) 
       | Ty.isActiveRefType ty = 
-          named_tmp_var "new" ty $
-                        Cast (Ptr . AsType $ class_type_name ty)
-                        (Call (Nam "encore_create")
-                              [Amp $ runtime_type_name ty])
+          named_tmp_var "new" ty $ Cast (Ptr . AsType $ class_type_name ty)
+                                        (Call (Nam "encore_create")
+                                              [Amp $ runtime_type_name ty])
       | otherwise = 
           do na <- Ctx.gen_named_sym "new"
              let size = Sizeof . AsType $ class_type_name ty
-             return $ (Var na, Assign (Decl (translate ty, Var na))
-                                      (Call (Nam "encore_alloc") [size]))
+                 the_new = Assign (Decl (translate ty, Var na))
+                                  (Call (Nam "encore_alloc") [size])
+                 init = Assign (Var na `Arrow` self_type_field) (Amp $ runtime_type_name ty)
+             return $ (Var na, Seq [the_new, init])
 
   translate (A.Peer {A.ty})
       | Ty.isActiveRefType ty =

--- a/src/back/CodeGen/Header.hs
+++ b/src/back/CodeGen/Header.hs
@@ -151,8 +151,9 @@ generate_header p =
      passive_types = map passive_type $ filter (not . A.isActive) allclasses
                  where
                    passive_type A.Class{A.cname, A.fields} = 
-                       StructDecl (AsType $ class_type_name cname) 
-                                  (zip
+                       StructDecl (AsType $ class_type_name cname)
+                                  ((Ptr pony_type_t, AsLval $ self_type_field) :
+                                   zip
                                    (map (translate . A.ftype) fields)
                                    (map (Var . show . A.fname) fields))
 

--- a/src/runtime/encore/encore.c
+++ b/src/runtime/encore/encore.c
@@ -297,14 +297,18 @@ bool gc_disabled()
 
 encore_actor_t *encore_create(pony_type_t *type)
 {
-  return (encore_actor_t *)pony_create(type);
+  encore_actor_t *new = (encore_actor_t *)pony_create(type);
+  new->_enc__self_type = type;
+  return new;
 }
 
 encore_actor_t *encore_peer_create(pony_type_t *type)
 {
   //todo: this should create an actor in another work pool
   // printf("warning: creating peer not implemented by runtime\n");
-  return (encore_actor_t *)pony_create(type);
+  encore_actor_t *new = (encore_actor_t *)pony_create(type);
+  new->_enc__self_type = type;
+  return new;
 }
 
 /// Allocate s bytes of memory, zeroed out

--- a/src/runtime/encore/encore.h
+++ b/src/runtime/encore/encore.h
@@ -100,6 +100,7 @@ struct encore_actor
 #else
   ucontext_t *saved;
 #endif
+  pony_type_t *_enc__self_type;
 };
 
 /// Create a new Encore actor


### PR DESCRIPTION
The struct for each class (passive and active) now has a post
`_enc__self_type` that is a pointer to its own `pony_type_t`.
So far, nothing interesting is done with this pointer!
