### PR TITLE
Pass program source file to `test.sh` in basic.

### DIFF
--- a/src/tests/encore/basic/Makefile
+++ b/src/tests/encore/basic/Makefile
@@ -2,7 +2,7 @@ ENCORE_SOURCES=$(shell ls *.enc)
 ENCORE_TARGETS=$(ENCORE_SOURCES:.enc=)
 
 test: embed_tl.o
-	@./test.sh $(ENCORE_TARGETS)
+	@./test.sh $(ENCORE_SOURCES)
 
 embed_tl.o: embed_tl.c embed_tl.h
 	clang -c embed_tl.c

--- a/src/tests/encore/basic/test.sh
+++ b/src/tests/encore/basic/test.sh
@@ -13,8 +13,8 @@ function run_test {
     # piped into that script. The test is successful iff the script
     # returns normally (exit 0).
 
-    program=$1
-    source=$1.enc
+    source=$1
+    program=${source%.enc}
     # compile and, if successful, run the program:
     output=$(${ENCOREC} $source && ./$program)
     checking_script=./$program.chk
@@ -48,11 +48,12 @@ passed=0
 failed=0
 failed_list=()
 
+# skipped=(async.enc)
 skipped=()
 progs=("$@")
 for rm in "${skipped[@]}"
 do
-    progs=(${progs[@]/$rm})
+    progs=(${progs[@]/#$rm})
 done
 for prog in "${progs[@]}"
 do


### PR DESCRIPTION
After stripping the suffix, some programs' names are prefix of others.
eg. async (async.enc) is the prefix of async_block (async_block.enc),
which confuses the skipping process in `test.sh`.
