### PR TITLE
Getting rid of warnings in `PrettyPrinter.hs`

### DIFF
--- a/src/ir/AST/AST.hs
+++ b/src/ir/AST/AST.hs
@@ -255,10 +255,10 @@ data Expr = Skip {emeta :: Meta Expr}
                    ty    :: Type,
                    code  :: String}
           | Unary {emeta :: Meta Expr,
-                   op    :: Op,
+                   uop   :: UnaryOp,
                    operand  :: Expr }
           | Binop {emeta :: Meta Expr,
-                   op :: Op,
+                   binop :: BinaryOp,
                    loper :: Expr,
                    roper :: Expr} deriving(Show, Eq)
 

--- a/src/ir/Identifiers.hs
+++ b/src/ir/Identifiers.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -fwarn-incomplete-patterns #-}
+
 {-|
 
 Types for different kinds of identifiers
@@ -17,18 +19,38 @@ type QName = [Name]
 thisName :: Name
 thisName = Name "this"
 
--- | The supported (infix) operators
-data Op = AND | OR | NOT | LT | GT | LTE | GTE | EQ | NEQ | PLUS | MINUS | TIMES | DIV | MOD deriving(Read, Eq)
-instance Show Op where
+-- | The supported binary operators
+data BinaryOp = AND
+              | OR
+              | LT
+              | GT
+              | LTE
+              | GTE
+              | EQ
+              | NEQ
+              | PLUS
+              | MINUS
+              | TIMES
+              | DIV
+              | MOD 
+                deriving(Read, Eq)
+
+instance Show BinaryOp where
     show Identifiers.AND = "and"
-    show Identifiers.OR = "or"
+    show Identifiers.OR  = "or"
+    show Identifiers.LT  = "<"
+    show Identifiers.GT  = ">"
+    show Identifiers.LTE = "<="
+    show Identifiers.GTE = ">="
+    show Identifiers.EQ  = "="
+    show NEQ             = "!="
+    show PLUS            = "+"
+    show MINUS           = "-"
+    show TIMES           = "*"
+    show DIV             = "/"
+    show MOD             = "%"
+
+data UnaryOp = NOT deriving(Read, Eq)
+
+instance Show UnaryOp where
     show Identifiers.NOT = "not"
-    show Identifiers.LT = "<"
-    show Identifiers.GT = ">"
-    show Identifiers.EQ = "="
-    show NEQ            = "!="
-    show PLUS           = "+"
-    show MINUS          = "-"
-    show TIMES          = "*"
-    show DIV            = "/"
-    show MOD            = "%"

--- a/src/opt/Optimizer/Optimizer.hs
+++ b/src/opt/Optimizer/Optimizer.hs
@@ -27,8 +27,8 @@ optimizerPasses = [constantFolding, constructors]
 constantFolding :: Expr -> Expr
 constantFolding = extend foldConst
     where
-      foldConst (Binop {emeta = meta, op = PLUS, 
-                        loper = IntLiteral{intLit = m}, 
+      foldConst (Binop {emeta = meta, binop = PLUS,
+                        loper = IntLiteral{intLit = m},
                         roper = IntLiteral{intLit = n}}) = 
           IntLiteral{emeta = meta, intLit = (m + n)}
       foldConst e = e

--- a/src/types/Typechecker/Typechecker.hs
+++ b/src/types/Typechecker/Typechecker.hs
@@ -797,12 +797,12 @@ instance Checkable Expr where
     --  E |- operand : bool
     -- -------------------------
     --  E |- not operand : bool
-    typecheck unary@(Unary {op, operand})
-      | op == (Identifiers.NOT) = do
+    typecheck unary@(Unary {uop, operand})
+      | uop == (Identifiers.NOT) = do
         eOperand <- pushTypecheck operand
         let eType = AST.getType eOperand
         unless (isBoolType eType) $
-                tcError $ "Operator '" ++ show op ++ "' is only defined for boolean types\n" ++
+                tcError $ "Operator '" ++ show uop ++ "' is only defined for boolean types\n" ++
                           "Expression '" ++ (show $ ppExpr eOperand) ++ "' has type '" ++ show eType ++ "'"
         return $ setType boolType unary { operand = eOperand }
 
@@ -821,42 +821,42 @@ instance Checkable Expr where
     --  E |- loper op roper : bool
     --
     -- etc.
-    typecheck binop@(Binop {op, loper, roper})
-      | op `elem` boolOps = do
+    typecheck bin@(Binop {binop, loper, roper})
+      | binop `elem` boolOps = do
           eLoper <- pushTypecheck loper
           eRoper <- pushTypecheck roper
           let lType = AST.getType eLoper
               rType = AST.getType eRoper
           unless (isBoolType lType && isBoolType rType) $
-                  tcError $ "Operator '"++ show op ++ "' is only defined for boolean types\n" ++
+                  tcError $ "Operator '"++ show binop ++ "' is only defined for boolean types\n" ++
                           "   Left type: '" ++ (show $ lType) ++ "'\n" ++
                           "   Right type: '" ++ (show $ rType) ++ "'"
-          return $ setType boolType binop {loper = eLoper, roper = eRoper}
-      | op `elem` cmpOps =
+          return $ setType boolType bin {loper = eLoper, roper = eRoper}
+      | binop `elem` cmpOps =
           do eLoper <- pushTypecheck loper
              eRoper <- pushTypecheck roper
              let lType = AST.getType eLoper
                  rType = AST.getType eRoper
              unless (isNumeric lType && isNumeric rType) $
-                    tcError $ "Operator '"++ show op ++ "' is only defined for numeric types\n" ++
+                    tcError $ "Operator '"++ show binop ++ "' is only defined for numeric types\n" ++
                           "   Left type: '" ++ (show $ lType) ++ "'\n" ++
                           "   Right type: '" ++ (show $ rType) ++ "'"
-             return $ setType boolType binop {loper = eLoper, roper = eRoper}
-      | op `elem` eqOps =
+             return $ setType boolType bin {loper = eLoper, roper = eRoper}
+      | binop `elem` eqOps =
           do eLoper <- pushTypecheck loper
              eRoper <- pushHasType roper (AST.getType eLoper)
-             return $ setType boolType binop {loper = eLoper, roper = eRoper}
-      | op `elem` arithOps =
+             return $ setType boolType bin {loper = eLoper, roper = eRoper}
+      | binop `elem` arithOps =
           do eLoper <- pushTypecheck loper
              eRoper <- pushTypecheck roper
              let lType = AST.getType eLoper
                  rType = AST.getType eRoper
              unless (isNumeric lType && isNumeric rType) $
-                    tcError $ "Operator '"++ show op ++ "' is only defined for numeric types\n" ++
+                    tcError $ "Operator '"++ show binop ++ "' is only defined for numeric types\n" ++
                           "   Left type: '" ++ (show $ lType) ++ "'\n" ++
                           "   Right type: '" ++ (show $ rType) ++ "'"
-             return $ setType (coerceTypes lType rType) binop {loper = eLoper, roper = eRoper}
-      | otherwise = tcError $ "Undefined binary operator '" ++ show op ++ "'"
+             return $ setType (coerceTypes lType rType) bin {loper = eLoper, roper = eRoper}
+      | otherwise = tcError $ "Undefined binary operator '" ++ show binop ++ "'"
       where
         boolOps  = [Identifiers.AND, Identifiers.OR]
         cmpOps   = [Identifiers.LT, Identifiers.GT, Identifiers.LTE, Identifiers.GTE]


### PR DESCRIPTION
This commit gets rid of the warnings given by missing cases in the
pretty-printer. It had just been bugging me for ages.
