### PR TITLE
Added `*.dyn_hi` and `*.dyn_o` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ cabal-dev
 *.dSYM
 *.o
 *.hi
+*.dyn_hi
+*.dyn_o
 *.chi
 *.chs.h
 *~


### PR DESCRIPTION
I suddenly started getting these files all over the place, and since we
already have `*.hi` and `*.o` it makes sense to add them to the common
`.gitignore`.
