### PR TITLE
Rename `traverse` to `mapProgram` to avoid name clash in prelude.

### DIFF
--- a/src/back/CodeGen/Program.hs
+++ b/src/back/CodeGen/Program.hs
@@ -41,7 +41,7 @@ instance Translatable A.Program Emitted where
       shared = generate_shared prog ctable
       name_and_class p@A.Program{A.classes} =
         [(Ty.getId (A.cname c), translate c ctable) | c <- classes]
-      classes = A.traverse prog name_and_class
+      classes = A.mapProgram prog name_and_class
     in
       Emitted{classes, header, shared}
     where

--- a/src/front/TopLevel.hs
+++ b/src/front/TopLevel.hs
@@ -48,7 +48,7 @@ data Option = GCC | Clang | Run |
               KeepCFiles | Undefined String |
               Output FilePath | Source FilePath | Imports [FilePath] |
               Intermediate Phase | TypecheckOnly
-	deriving Eq
+              deriving Eq
 
 parseArguments :: [String] -> ([FilePath], [FilePath], [Option])
 parseArguments args =

--- a/src/ir/AST/AST.hs
+++ b/src/ir/AST/AST.hs
@@ -389,8 +389,8 @@ traverseProgram f g p@(Program{imports}) =
       lift :: (Program -> b) -> ImportDecl -> b
       lift h (PulledImport{iprogram}) = h iprogram
 
-traverse :: Program -> (Program -> [a]) -> [a]
-traverse program f =
+mapProgram :: Program -> (Program -> [a]) -> [a]
+mapProgram program f =
   let
     programs = flatten_imports program
   in
@@ -412,7 +412,7 @@ getTrait t p =
     fromJust $ find (match t) traits
 
 allTraits :: Program -> [Trait]
-allTraits p = traverse p traits
+allTraits p = mapProgram p traits
 
 merge a b = a ++ concat b
 

--- a/src/types/Typechecker/Environment.hs
+++ b/src/types/Typechecker/Environment.hs
@@ -65,7 +65,7 @@ empty_env = Env {
 
 buildEnvironment :: Program -> Either TCError Environment
 buildEnvironment p@(Program{functions, classes, imports}) =
-  merge_envs $ traverse p buildEnvironment'
+  merge_envs $ mapProgram p buildEnvironment'
   where
     buildEnvironment' :: Program -> [Either TCError Environment]
     buildEnvironment' p@(Program {functions, classes, traits, imports}) =


### PR DESCRIPTION
Should fix #195 
