### PR TITLE
Refactoring to get rid of `traverseProgram`

### DIFF
--- a/src/back/CodeGen/ClassTable.hs
+++ b/src/back/CodeGen/ClassTable.hs
@@ -13,10 +13,8 @@ type MethodTable = [(Name, MethodDecl)]
 type ClassTable  = [(Type, (FieldTable, MethodTable))]
 
 build_class_table :: Program -> ClassTable
-build_class_table = traverseProgram f merge
+build_class_table = traverseProgram ((map get_class_entry) . classes)
   where
-    f Program{classes} = map get_class_entry classes
-    merge a b = a ++ concat b
     get_class_entry Class{cname, fields, methods} =
       (cname, ((map get_field_entry fields), (map get_method_entry methods)))
     get_field_entry f@Field{fname} = (fname, f)

--- a/src/back/CodeGen/Program.hs
+++ b/src/back/CodeGen/Program.hs
@@ -41,7 +41,7 @@ instance Translatable A.Program Emitted where
       shared = generate_shared prog ctable
       name_and_class p@A.Program{A.classes} =
         [(Ty.getId (A.cname c), translate c ctable) | c <- classes]
-      classes = A.traverse prog name_and_class
+      classes = A.traverseProgram name_and_class prog
     in
       Emitted{classes, header, shared}
     where

--- a/src/back/CodeGen/Shared.hs
+++ b/src/back/CodeGen/Shared.hs
@@ -17,7 +17,7 @@ generate_shared prog@(A.Program{A.functions, A.imports}) ctable =
     Concat $
       (LocalInclude "header.h") :
 
-      A.traverseProgram f combine prog ++
+      embedded_code ++
 
       -- [comment_section "Shared messages"] ++
       -- shared_messages ++
@@ -30,11 +30,11 @@ generate_shared prog@(A.Program{A.functions, A.imports}) ctable =
 
       global_functions = map (\fun -> translate fun ctable) allfunctions
 
-      f A.Program{A.etl = A.EmbedTL{A.etlbody}} =
-        [comment_section "Embedded Code"] ++
-        [Embed etlbody]
-
-      combine a b = [comment_section "Imported functions"] ++ concat b ++ a
+      embedded_code = A.traverseProgram embedded prog
+        where
+          embedded A.Program{A.source, A.etl = A.EmbedTL{A.etlbody}} =
+              [comment_section $ "Embedded Code from " ++ show source] ++
+              [Embed etlbody]
 
       shared_messages = [msg_alloc_decl, msg_fut_resume_decl, msg_fut_suspend_decl, msg_fut_await_decl, msg_fut_run_closure_decl]
           where

--- a/src/parser/Parser/Parser.hs
+++ b/src/parser/Parser/Parser.hs
@@ -140,6 +140,7 @@ typ  =  try arrow
                         return $ typeVar ty
 program :: Parser Program
 program = do
+  source <- sourceName <$> getPosition
   optional hashbang
   whiteSpace
   bundle <- bundledecl
@@ -149,7 +150,7 @@ program = do
   decls <- many $ (Left <$> trait) <|> (Right <$> classDecl)
   let (traits, classes) = partitionEithers decls
   eof
-  return $ Program{bundle, etl, imports, functions, traits, classes}
+  return $ Program{source, bundle, etl, imports, functions, traits, classes}
     where
       hashbang = do string "#!"
                     many (noneOf "\n\r")

--- a/src/types/Typechecker/Environment.hs
+++ b/src/types/Typechecker/Environment.hs
@@ -64,8 +64,8 @@ empty_env = Env {
 }
 
 buildEnvironment :: Program -> Either TCError Environment
-buildEnvironment p@(Program{functions, classes, imports}) =
-  merge_envs $ traverse p buildEnvironment'
+buildEnvironment =
+  merge_envs . (traverseProgram buildEnvironment')
   where
     buildEnvironment' :: Program -> [Either TCError Environment]
     buildEnvironment' p@(Program {functions, classes, traits, imports}) =


### PR DESCRIPTION
All uses of `traverseProgram` have been replaced by uses of `traverse`,
which has now been renamed to `traverseProgram` (which should fix #195).
