### PR TITLE
Support for `val` fields

### DIFF
--- a/emacs/encore-mode.el
+++ b/emacs/encore-mode.el
@@ -10,7 +10,7 @@
 ;; init-file. There is a hook to enable encore-mode for all files
 ;; with extension .enc.
 
-(setq encore-keywords '("and" "await" "class" "chain" "def" "else" "eos" "get" "getNext" "if" "in" "let" "new" "not" "or" "passive" "print" "repeat" "stream" "suspend" "then" "this" "unless" "while" "yield" "async" "foreach"))
+(setq encore-keywords '("and" "async" "await" "class" "chain" "def" "else" "eos" "foreach" "get" "getNext" "if" "in" "let" "new" "not" "or" "passive" "print" "repeat" "require" "stream" "suspend" "then" "this" "trait" "unless" "val" "while" "yield" ))
 (setq encore-danger-words '("embed" "body" "end"))
 (setq encore-constants '("true" "false" "null"))
 (setq encore-primitives '("int" "string" "void" "bool"))

--- a/mylittlepony.cabal
+++ b/mylittlepony.cabal
@@ -30,7 +30,7 @@ executable encorec
                   , CPP
                   , ScopedTypeVariables
   build-depends: MissingH
-               , base >=4.7 && <=4.8.0.0
+               , base >=4.7 && <=4.8.1.0
                , containers >= 0.5.5.1
                , directory >=1.2 && <1.3
                , hashable

--- a/src/ir/AST/AST.hs
+++ b/src/ir/AST/AST.hs
@@ -136,14 +136,24 @@ instance HasMeta TraitDecl where
     t{tmeta = AST.Meta.setType ty tmeta, tname = ty}
   showWithKind Trait{tname} = "trait '" ++ getId tname ++ "'"
 
+data Modifier = Val
+                deriving(Eq)
+
+instance Show Modifier where
+    show Val = "val"
+
 data FieldDecl = Field {
   fmeta :: Meta FieldDecl,
+  fmods :: [Modifier],
   fname :: Name,
   ftype :: Type
 }
 
 instance Show FieldDecl where
-  show f@Field{fname,ftype} = show fname ++ " : " ++ show ftype
+  show f@Field{fmods,fname,ftype} =
+      smods ++ show fname ++ " : " ++ show ftype
+    where
+      smods = concatMap ((++ " ") . show) fmods
 
 instance Eq FieldDecl where
   a == b = fname a == fname b
@@ -153,6 +163,9 @@ instance HasMeta FieldDecl where
     setMeta f m = f{fmeta = m}
     setType ty f@(Field {fmeta, ftype}) = f {fmeta = AST.Meta.setType ty fmeta, ftype = ty}
     showWithKind Field{fname} = "field '" ++ show fname ++ "'"
+
+isValField :: FieldDecl -> Bool
+isValField = (Val `elem`) . fmods
 
 data ParamDecl = Param {
   pmeta :: Meta ParamDecl,
@@ -182,6 +195,9 @@ isStreamMethod _ = False
 
 isMainMethod :: Type -> Name -> Bool
 isMainMethod ty name = isMainType ty && (name == Name "main")
+
+isConstructor :: MethodDecl -> Bool
+isConstructor m = mname m == Name "_init"
 
 instance Eq MethodDecl where
   a == b = mname a == mname b

--- a/src/ir/AST/PrettyPrinter.hs
+++ b/src/ir/AST/PrettyPrinter.hs
@@ -104,7 +104,7 @@ ppClassDecl Class {cname, cfields, cmethods} =
                    vcat (map ppMethodDecl cmethods))
 
 ppFieldDecl :: FieldDecl -> Doc
-ppFieldDecl Field {fname, ftype} = ppName fname <+> ppColon <+> ppType ftype
+ppFieldDecl = text . show
 
 ppParamDecl :: ParamDecl -> Doc
 ppParamDecl (Param {pname, ptype}) =  ppName pname <+> text ":" <+> ppType ptype

--- a/src/parser/Parser/Parser.hs
+++ b/src/parser/Parser/Parser.hs
@@ -49,7 +49,7 @@ lexer =
      "while", "get", "yield", "eos", "getNext", "new", "this", "await",
      "suspend", "and", "or", "not", "true", "false", "null", "embed", "body",
      "end", "where", "Fut", "Par", "Stream", "import", "qualified", "bundle",
-     "peer", "async", "finish", "foreach", "trait", "require"
+     "peer", "async", "finish", "foreach", "trait", "require", "val"
    ],
    P.reservedOpNames = [
      ":", "=", "==", "!=", "<", ">", "<=", ">=", "+", "-", "*", "/", "%", "->",
@@ -235,11 +235,7 @@ traitDecl = do
 traitField :: Parser FieldDecl
 traitField = do
   reserved "require"
-  fmeta <- meta <$> getPosition
-  fname <- Name <$> identifier
-  colon
-  ftype <- typ
-  return Field{fmeta, fname, ftype}
+  fieldDecl
 
 capability :: Parser Type
 capability = do
@@ -267,12 +263,25 @@ classDecl = do
               methods <- many methodDecl
               return (fields, methods)
 
+modifier :: Parser Modifier
+modifier = val
+           <?>
+           "modifier"
+    where
+      val = do
+        reserved "val"
+        return Val
+
 fieldDecl :: Parser FieldDecl
-fieldDecl = do pos <- getPosition
-               f <- identifier
+fieldDecl = do fmeta <- meta <$> getPosition
+               fmods <- many modifier
+               fname <- Name <$> identifier
                colon
-               ty <- typ
-               return $ Field (meta pos) (Name f) ty
+               ftype <- typ
+               return Field{fmeta
+                           ,fmods
+                           ,fname
+                           ,ftype}
 
 paramDecl :: Parser ParamDecl
 paramDecl = do pos <- getPosition

--- a/src/tests/encore/basic/parametricClasses.enc
+++ b/src/tests/encore/basic/parametricClasses.enc
@@ -1,10 +1,10 @@
 class Cell<a>
-  val : a
-  def init(val : a) : void
-    this.val = val
+  value : a
+  def init(value : a) : void
+    this.value = value
 
   def getVal() : a
-    this.val
+    this.value
 
 class Pair<a, b>
   fst : a

--- a/src/tests/encore/basic/valFields.enc
+++ b/src/tests/encore/basic/valFields.enc
@@ -1,0 +1,65 @@
+trait Mappable<v>
+  require value : v
+  require val next : Mappable<v>
+  def map(f : v -> v) : void{
+    this.value = f(this.value);
+    if this.next != null
+    then this.next.map(f)
+  }
+
+passive class List<v> : Mappable<v>
+  value : v
+  next : List<v>
+
+  def init(value : v, next : List<v>) : void{
+    this.value = value;
+    this.next = next;
+  }
+
+  def add(value : v) : void
+    if this.next == null
+    then this.next = new List<v>(value, null)
+    else this.next.add(value)
+
+
+passive class Link<v> : Mappable<v>
+  value : v
+  next : Link<v>
+
+  def init(value : v, next : Link<v>) : void{
+    this.value = value;
+    this.next = next;
+  }
+
+trait Push<v>
+  require top : Link<v>
+  def push(value : v) : void
+    this.top = new Link<v>(value, this.top)
+
+passive class Stack<v> : Push
+  val top : Link<v>
+  def init() : void
+    this.top = null
+
+  def map(f : v -> v) : void
+    this.top.map(f)
+
+class Main
+  def main() : void
+    let l = new List<int>(1, null)
+        s = new Stack<string>()
+        bump = \ (x : int) -> x + 1
+        showNum = \ (x : int) -> {print x; x}
+        showString = \ (x : string) -> {print x; x}
+    in{
+      l.add(2);
+      l.add(3);
+      l.add(4);
+      l.map(bump);
+      l.map(showNum);
+      s.push("four");
+      s.push("three");
+      s.push("two");
+      s.push("one");
+      s.map(showString);
+    }

--- a/src/tests/encore/basic/valFields.out
+++ b/src/tests/encore/basic/valFields.out
@@ -1,0 +1,8 @@
+2
+3
+4
+5
+one
+two
+three
+four

--- a/src/types/Typechecker/Environment.hs
+++ b/src/types/Typechecker/Environment.hs
@@ -26,6 +26,7 @@ module Typechecker.Environment(Environment,
                                bindTypes,
                                bindings,
                                backtrace,
+                               currentMethod,
                                pushBT,
                                refTypeParameters
                                ) where
@@ -88,6 +89,9 @@ pushBT :: Pushable a => a -> Environment -> Environment
 pushBT x env@Env{bt} = env{bt = push x bt}
 
 backtrace = bt
+
+currentMethod :: Environment -> MethodDecl
+currentMethod = currentMethodFromBacktrace . bt
 
 fieldLookup :: Type -> Name -> Environment -> Maybe FieldDecl
 fieldLookup t f env

--- a/src/types/Typechecker/Prechecker.hs
+++ b/src/types/Typechecker/Prechecker.hs
@@ -117,9 +117,11 @@ instance Precheckable MethodDecl where
       mparams' <- mapM precheck $ mparams m
       thisType <- liftM fromJust $ asks $ varLookup thisName
       when (isMainMethod thisType (mname m)) checkMainParams
-      when (isStreamMethod m) $
+      when (isStreamMethod m) $ do
            unless (isActiveClassType thisType) $
                   tcError "Cannot have streaming methods in a passive class"
+           when (isConstructor m) $
+                tcError "Constructor cannot be streaming"
       return $ setType mtype' m{mparams = mparams'}
       where
         checkMainParams =

--- a/src/types/Typechecker/TypeError.hs
+++ b/src/types/Typechecker/TypeError.hs
@@ -9,7 +9,7 @@ module Typechecker.TypeError (Backtrace
                              ,emptyBT
                              ,Pushable(push)
                              ,TCError(TCError)
-                             ,currentMethod) where
+                             ,currentMethodFromBacktrace) where
 
 import Text.PrettyPrint
 import Text.Parsec(SourcePos)
@@ -53,8 +53,8 @@ type Backtrace = [(SourcePos, BacktraceNode)]
 emptyBT :: Backtrace
 emptyBT = []
 
-currentMethod :: Backtrace -> MethodDecl
-currentMethod [] =
+currentMethodFromBacktrace :: Backtrace -> MethodDecl
+currentMethodFromBacktrace [] =
   let
     err = unlines
       [
@@ -62,8 +62,8 @@ currentMethod [] =
         "to get current method when not in a method"
       ]
   in error err
-currentMethod ((_, BTMethod m):_) = m
-currentMethod (_:bt) = currentMethod bt
+currentMethodFromBacktrace ((_, BTMethod m):_) = m
+currentMethodFromBacktrace (_:bt) = currentMethodFromBacktrace bt
 
 -- | A type class for unifying the syntactic elements that can be pushed to the
 -- backtrace stack.

--- a/src/types/Typechecker/Util.hs
+++ b/src/types/Typechecker/Util.hs
@@ -4,7 +4,7 @@
 
 module Typechecker.Util where
 
-import Types
+import Types as Ty
 import qualified AST.AST as AST
 import Data.List
 import Text.Printf (printf)
@@ -84,3 +84,10 @@ assertDistinct something l =
   in
     unless (null duplicates) $
       tcError $ printf "Duplicate %s of %s" something $ AST.showWithKind first
+
+classOrTraitName :: Type -> String
+classOrTraitName ty
+    | isClassType ty = "class '" ++ getId ty ++ "'"
+    | isTraitType ty = "trait '" ++ getId ty ++ "'"
+    | otherwise = error $ "Util.hs: No class or trait name for " ++
+                          Ty.showWithKind ty


### PR DESCRIPTION
This commit adds support for declaring read-only fields. Such a field is
declared using the keyword `val` and may not be written to, except in
constructors. This allows us to have covariance on field types for
included traits:

```
trait HasPet
  require val pet : Animal

passive class DogPerson : HasPet
  pet : Dog

passive class CatPerson : HasPet
  pet : Cat
```

(where `Dog <: Animal` and `Cat <: Animal`)

Since the methods of `HasPet` cannot update the field `pet`, the actual
type of `pet` can be any subtype of `Animal`, which increases trait
reuse. `val`-fields are also needed for `readonly` capabilities. Having
`val`-fields in a class means that any updates of the field must happen
in the constructor, or in one of the included methods (that does not
have a "`val` view" of the trait). See the added test for a slightly
more realistic usage.

Minor fixes in this commit is an update of the keywords in
`encore-mode.el`, insertion of C-level type casts for binary
operators (see #208) and an update of the cabal dependencies to support
`base 4.8.1.0`.
