### PR TITLE
Refactoring to support recursive capabilities

### DIFF
--- a/mylittlepony.cabal
+++ b/mylittlepony.cabal
@@ -21,6 +21,7 @@ executable encorec
   default-extensions: NamedFieldPuns
                     , FlexibleContexts
                     , GADTs
+                    , Rank2Types
   other-extensions: FlexibleInstances
                   , MultiParamTypeClasses
                   , StandaloneDeriving

--- a/src/back/CodeGen/ClassDecl.hs
+++ b/src/back/CodeGen/ClassDecl.hs
@@ -196,13 +196,13 @@ translatePassiveClass cdecl@(A.Class{A.cname, A.cfields, A.cmethods}) ctable =
                    (Comm "Stub! Might be used when we have dynamic dispatch on passive classes")
 
 trait_method_selector :: ClassTable -> A.ClassDecl -> CCode Toplevel
-trait_method_selector ctable A.Class{A.cname} =
+trait_method_selector ctable A.Class{A.cname, A.ccapability} =
   let
     ret_type = Static (Ptr void)
     fname = trait_method_selector_name
     args = [(Typ "int" , Var "id")]
     cond = Var "id"
-    trait_types = Ty.getImplementedTraits cname
+    trait_types = Ty.traitsFromCapability ccapability
     trait_methods = map (`lookup_methods` ctable) trait_types
     cases = concat $ zipWith (trait_case cname) trait_types trait_methods
     err = String "error, got invalid id: %d"

--- a/src/back/CodeGen/Expr.hs
+++ b/src/back/CodeGen/Expr.hs
@@ -198,7 +198,7 @@ instance Translatable A.Expr (State Ctx.Context (CCode Lval, CCode Stat)) where
           where
             lhs_type = A.getType lhs
             rhs_type = A.getType rhs
-            need_up_cast = rhs_type `Ty.strictSubtypeOf` lhs_type
+            need_up_cast = rhs_type /= lhs_type
             cast = Cast (translate lhs_type)
         mk_lval (A.VarAccess {A.name}) =
             do ctx <- get
@@ -648,7 +648,7 @@ instance Translatable A.Expr (State Ctx.Context (CCode Lval, CCode Stat)) where
 cast_arguments :: Ty.Type -> CCode Lval -> Ty.Type -> CCode Expr
 cast_arguments expected targ targ_type
   | Ty.isTypeVar expected = as_encore_arg_t (translate targ_type) $ AsExpr targ
-  | targ_type `Ty.strictSubtypeOf` expected = Cast (translate expected) targ
+  | targ_type /= expected = Cast (translate expected) targ
   | otherwise = AsExpr targ
 
 trait_method call@(A.MethodCall{A.target=target, A.name=name, A.args=args}) =

--- a/src/back/CodeGen/Preprocessor.hs
+++ b/src/back/CodeGen/Preprocessor.hs
@@ -17,8 +17,8 @@ injectTraitsToClasses p@A.Program{A.classes} =
   p{A.classes = map injectTraitsToClass classes}
   where
     injectTraitsToClass :: A.ClassDecl -> A.ClassDecl
-    injectTraitsToClass c@A.Class{A.cname} =
-        foldr injectTraitToClass c (Ty.getImplementedTraits cname)
+    injectTraitsToClass c@A.Class{A.cname, A.ccapability} =
+        foldr injectTraitToClass c (Ty.traitsFromCapability ccapability)
 
     injectTraitToClass :: Ty.Type -> A.ClassDecl -> A.ClassDecl
     injectTraitToClass traitType c@A.Class{A.cmethods} =

--- a/src/ir/AST/AST.hs
+++ b/src/ir/AST/AST.hs
@@ -97,10 +97,11 @@ instance HasMeta Function where
   showWithKind Function{funname, funtype} = "function '" ++ show funname ++ "'"
 
 data ClassDecl = Class {
-  cmeta   :: Meta ClassDecl,
-  cname   :: Type,
-  cfields  :: [FieldDecl],
-  cmethods :: [MethodDecl]
+  cmeta       :: Meta ClassDecl,
+  cname       :: Type,
+  ccapability :: Type,
+  cfields     :: [FieldDecl],
+  cmethods    :: [MethodDecl]
 } deriving (Show)
 
 instance Eq ClassDecl where

--- a/src/parser/Parser/Parser.hs
+++ b/src/parser/Parser/Parser.hs
@@ -250,10 +250,11 @@ classDecl = do
   reserved "class"
   name <- identifier
   params <- option [] (angles $ commaSep1 typeVariable)
-  capability <- option incapability (do{reservedOp ":"; capability})
+  ccapability <- option incapability (do{reservedOp ":"; capability})
   (cfields, cmethods) <- maybeBraces classBody
   return Class{cmeta
-              ,cname = refKind (refTypeWithParams name params) capability
+              ,cname = refKind (refTypeWithParams name params)
+              ,ccapability
               ,cfields
               ,cmethods
               }

--- a/src/tests/encore/basic/valFields.enc
+++ b/src/tests/encore/basic/valFields.enc
@@ -36,7 +36,7 @@ trait Push<v>
   def push(value : v) : void
     this.top = new Link<v>(value, this.top)
 
-passive class Stack<v> : Push
+passive class Stack<v> : Push<v>
   val top : Link<v>
   def init() : void
     this.top = null

--- a/src/types/Typechecker/Environment.hs
+++ b/src/types/Typechecker/Environment.hs
@@ -15,6 +15,7 @@ module Typechecker.Environment(Environment,
                                refTypeLookupUnsafe,
                                methodLookup,
                                fieldLookup,
+                               capabilityLookup,
                                varLookup,
                                isLocal,
                                typeVarLookup,
@@ -104,8 +105,7 @@ fieldLookup t f env
   | otherwise = error $ "Trying to lookup field in a non ref type " ++ show t
 
 matchMethod :: Name -> MethodDecl -> Bool
-matchMethod m Method{mname} = mname == m
-matchMethod m StreamMethod{mname} = mname == m
+matchMethod m = (==m) . mname
 
 traitMethodLookup :: Type -> Name -> Environment -> Maybe MethodDecl
 traitMethodLookup trait m env = do
@@ -117,14 +117,21 @@ methodLookup ty m env
   | isClassType ty = do
     cls <- classLookup ty env
     let c_m = find (matchMethod m) $ cmethods cls
+        traits = traitsFromCapability $ ccapability cls
         t_ms = map (\t -> traitMethodLookup t m env) traits
     ret <- find isJust (c_m:t_ms)
     return $ fromJust ret
   | isTraitType ty =
     traitMethodLookup ty m env
   | otherwise = error "methodLookup in non-ref type"
-    where
-      traits = getImplementedTraits ty
+
+capabilityLookup :: Type -> Environment -> Maybe Type
+capabilityLookup ty env
+    | isClassType ty = do
+        cls <- Map.lookup (getId ty) $ classTable env
+        return $ ccapability cls
+    | otherwise = error $ "Environment.hs: Tried to look up the capability " ++
+                          "of non-class type " ++ show ty
 
 traitLookup :: Type -> Environment -> Maybe TraitDecl
 traitLookup t env =

--- a/src/types/Typechecker/Prechecker.hs
+++ b/src/types/Typechecker/Prechecker.hs
@@ -29,9 +29,9 @@ precheckEncoreProgram p = do
   runReader (runExceptT (doPrecheck p)) env
 
 class Precheckable a where
-    doPrecheck :: a -> ExceptT TCError (Reader Environment) a
+    doPrecheck :: a -> TypecheckM a
 
-    precheck :: Pushable a => a -> ExceptT TCError (Reader Environment) a
+    precheck :: Pushable a => a -> TypecheckM a
     precheck x = local (pushBT x) $ doPrecheck x
 
 instance Precheckable Program where
@@ -90,19 +90,24 @@ instance Precheckable TraitDecl where
           assertDistinct "definition" tmethods
 
 instance Precheckable ClassDecl where
-    doPrecheck t@Class{cname, cfields, cmethods} = do
+    doPrecheck c@Class{cname, ccapability, cfields, cmethods} = do
       assertDistinctness
-      cname'    <- local addTypeParams $ resolveType cname
-      cfields'  <- mapM (local addTypeParams . precheck) cfields
-      cmethods' <- mapM (local (addTypeParams . addThis) . precheck) cmethods
-      return $ setType cname' t{cfields = cfields', cmethods = cmethods'}
+      cname'       <- local addTypeParams $ resolveType cname
+      ccapability' <- local addTypeParams $ resolveType ccapability
+      cfields'     <- mapM (local addTypeParams . precheck) cfields
+      cmethods'    <- mapM (local (addTypeParams . addThis) . precheck) cmethods
+      return $ setType cname' c{cfields = cfields'
+                               ,cmethods = cmethods'
+                               ,ccapability = ccapability'
+                               }
       where
         typeParameters = getTypeParameters cname
         addTypeParams = addTypeParameters typeParameters
         addThis = extendEnvironment [(thisName, cname)]
         assertDistinctness = do
             assertDistinctThing "declaration" "type parameter" typeParameters
-            assertDistinctThing "inclusion" "trait" $ getImplementedTraits cname
+            assertDistinctThing "inclusion" "trait" $
+                                traitsFromCapability ccapability
             assertDistinct "declaration" cfields
             assertDistinct "declaration" cmethods
 

--- a/src/types/Typechecker/Util.hs
+++ b/src/types/Typechecker/Util.hs
@@ -2,10 +2,24 @@
   Utility functions shared by several modules of "Typechecker".
 -}
 
-module Typechecker.Util where
+module Typechecker.Util(TypecheckM
+                       ,whenM
+                       ,unlessM
+                       ,tcError
+                       ,resolveType
+                       ,subtypeOf
+                       ,assertDistinctThing
+                       ,assertDistinct
+                       ,classOrTraitName
+                       ,findField
+                       ,findMethod
+                       ,findCapability
+                       ,formalBindings
+                       ) where
 
+import Identifiers
 import Types as Ty
-import qualified AST.AST as AST
+import AST.AST as AST
 import Data.List
 import Text.Printf (printf)
 
@@ -14,8 +28,28 @@ import Typechecker.TypeError
 import Typechecker.Environment
 import Control.Monad.Reader
 import Control.Monad.Except
+import Data.Maybe
 
--- | Convenience function for throwing an exception with the
+-- Monadic versions of common functions
+anyM :: (Monad m) => (a -> m Bool) -> [a] -> m Bool
+anyM p = foldM (\b x -> liftM (b ||) (p x)) False
+
+allM :: (Monad m) => (a -> m Bool) -> [a] -> m Bool
+allM p = foldM (\b x -> liftM (b &&) (p x)) True
+
+whenM :: (Monad m) => m Bool -> m () -> m ()
+whenM cond action = cond >>= (`when` action)
+
+unlessM :: (Monad m) => m Bool -> m () -> m ()
+unlessM cond action = cond >>= (`unless` action)
+
+-- | The monad in which all typechecking is performed. A function
+-- of return type @TypecheckM Bar@ may read from an 'Environment'
+-- and returns a @Bar@ or throws a typechecking exception.
+type TypecheckM a =
+    forall m . (MonadError TCError m, MonadReader Environment m) => m a
+
+-- | convenience function for throwing an exception with the
 -- current backtrace
 tcError msg =
     do bt <- asks backtrace
@@ -23,8 +57,7 @@ tcError msg =
 
 -- | @matchTypeParameterLength ty1 ty2@ ensures that the type parameter
 -- lists of its arguments have the same length.
-matchTypeParameterLength ::
-    Type -> Type -> ExceptT TCError (Reader Environment) ()
+matchTypeParameterLength :: Type -> Type -> TypecheckM ()
 matchTypeParameterLength ty1 ty2 = do
   let params1 = getTypeParameters ty1
       params2 = getTypeParameters ty2
@@ -36,32 +69,77 @@ matchTypeParameterLength ty1 ty2 = do
 -- | @resolveType ty@ checks all the components of @ty@, resolving
 -- reference types to traits or classes and making sure that any
 -- type variables are in the current environment.
-resolveType :: Type -> ExceptT TCError (Reader Environment) Type
+resolveType :: Type -> TypecheckM Type
 resolveType = typeMapM resolveSingleType
     where
       resolveSingleType ty
-          | isTypeVar ty = do
-              params <- asks typeParameters
-              unless (ty `elem` params) $
-                     tcError $ "Free type variables in type '" ++ show ty ++ "'"
-              return ty
-          | isRefType ty = do
-              result <- asks $ refTypeLookup ty
-              case result of
-                Just formal -> do
-                    matchTypeParameterLength formal ty
-                    return $ setTypeParameters formal $ getTypeParameters ty
-                Nothing ->
-                    tcError $ "Couldn't find class or trait '" ++ show ty ++ "'"
-          | otherwise = return ty
+        | isTypeVar ty = do
+            params <- asks typeParameters
+            unless (ty `elem` params) $
+                   tcError $ "Free type variables in type '" ++ show ty ++ "'"
+            return ty
+        | isRefType ty = do
+            result <- asks $ refTypeLookup ty
+            case result of
+              Just formal -> do
+                matchTypeParameterLength formal ty
+                return $ setTypeParameters formal $ getTypeParameters ty
+              Nothing ->
+                tcError $ "Couldn't find class or trait '" ++ show ty ++ "'"
+        | isCapabilityType ty = do
+            let traits = traitsFromCapability ty
+            mapM_ resolveSingleTrait traits
+            return ty
+        | otherwise = return ty
+        where
+          resolveSingleTrait t = do
+            result <- asks $ traitLookup t
+            when (isNothing result) $
+                   tcError $ "Couldn't find trait '" ++ getId t ++ "'"
+
+subtypeOf :: Type -> Type -> TypecheckM Bool
+subtypeOf ty1 ty2
+    | isNullType ty1 = return (isNullType ty2 || isRefType ty2)
+    | isClassType ty1 && isClassType ty2 =
+        ty1 `refSubtypeOf` ty2
+    | isClassType ty1 && isTraitType ty2 = do
+        traits <- getImplementedTraits ty1
+        anyM (`subtypeOf` ty2) traits
+    | isClassType ty1 && isCapabilityType ty2 = do
+        capability <- findCapability ty1
+        ty1 `capabilitySubtypeOf` ty2
+    | isTraitType ty1 && isTraitType ty2 =
+        ty1 `refSubtypeOf` ty2
+    | isTraitType ty1 && isCapabilityType ty2 = do
+        let traits = traitsFromCapability ty2
+        allM (ty1 `subtypeOf`) traits
+    | isCapabilityType ty1 && isTraitType ty2 = do
+        let traits = traitsFromCapability ty1
+        anyM (`subtypeOf` ty2) traits
+    | isCapabilityType ty1 && isCapabilityType ty2 =
+        ty1 `capabilitySubtypeOf` ty2
+    | otherwise = return (ty1 == ty2)
+    where
+      refSubtypeOf ref1 ref2
+          | getId ref1 == getId ref2
+          , params1 <- getTypeParameters ref1
+          , params2 <- getTypeParameters ref2
+          , length params1 == length params2 = do
+              results <- zipWithM subtypeOf params1 params2
+              return (and results)
+          | otherwise = return False
+
+      capabilitySubtypeOf cap1 cap2 = do
+        let traits1 = traitsFromCapability cap1
+            traits2 = traitsFromCapability cap2
+        allM (\t2 -> anyM (`subtypeOf` t2) traits1) traits2
 
 -- | Convenience function for asserting distinctness of a list of
 -- things. @assertDistinct "declaration" "field" [f : Foo, f :
 -- Bar]@ will throw an error with the message "Duplicate
 -- declaration of field 'f'".
-assertDistinctThing ::
-    (MonadError TCError m, MonadReader Environment m, Eq a, Show a) =>
-    String -> String -> [a] -> m ()
+assertDistinctThing :: (Eq a, Show a) =>
+                       String -> String -> [a] -> TypecheckM ()
 assertDistinctThing something kind l =
   let
     duplicates = l \\ nub l
@@ -75,8 +153,8 @@ assertDistinctThing something kind l =
 -- kind). @assertDistinct "declaration" [f : Foo, f : Bar]@ will
 -- throw an error with the message "Duplicate declaration of field
 -- 'f'".
-assertDistinct :: (MonadError TCError m, MonadReader Environment m,
-  Eq a, AST.HasMeta a) => String -> [a] -> m ()
+assertDistinct :: (Eq a, AST.HasMeta a) =>
+                  String -> [a] -> TypecheckM ()
 assertDistinct something l =
   let
     duplicates = l \\ nub l
@@ -91,3 +169,46 @@ classOrTraitName ty
     | isTraitType ty = "trait '" ++ getId ty ++ "'"
     | otherwise = error $ "Util.hs: No class or trait name for " ++
                           Ty.showWithKind ty
+
+findField :: Type -> Name -> TypecheckM FieldDecl
+findField ty f = do
+  result <- asks $ fieldLookup ty f
+  case result of
+    Just fdecl -> return fdecl
+    Nothing -> tcError $ "No field '" ++ show f ++ "' in " ++
+                         classOrTraitName ty
+
+findMethod :: Type -> Name -> TypecheckM MethodDecl
+findMethod ty name = do
+  m' <- asks $ methodLookup ty name
+  when (isNothing m') $ tcError $
+    concat [no_method name, " in ", classOrTraitName ty]
+  return $ fromJust m'
+  where
+    no_method (Name "_init") = "No constructor"
+    no_method n = concat ["No method '", show n, "'"]
+
+findCapability :: Type -> TypecheckM Type
+findCapability ty = do
+  result <- asks $ capabilityLookup ty
+  return $ fromMaybe err result
+    where
+        err = error $ "Util.hs: No capability in " ++ classOrTraitName ty
+
+formalBindings :: Type -> TypecheckM [(Type, Type)]
+formalBindings actual = do
+  origin <- asks $ refTypeLookupUnsafe actual
+  matchTypeParameterLength origin actual
+  let formals = getTypeParameters origin
+      actuals = getTypeParameters actual
+  return $ zip formals actuals
+
+getImplementedTraits :: Type -> TypecheckM [Type]
+getImplementedTraits ty
+    | isClassType ty = do
+        capability <- findCapability ty
+        fBindings <- formalBindings ty
+        let capability' = replaceTypeVars fBindings capability
+        return $ traitsFromCapability capability'
+    | otherwise =
+        error $ "Types.hs: Can't get implemented traits of type " ++ show ty


### PR DESCRIPTION
Before this commit, each occurrence of a `ClassType` stored its own
capability (implemented traits), but this turns out to be problematic.
Since a trait can be parameterized over a class type we can declare a
class as `passive class C : T<C>`, meaning that all occurrences of `C`
would indirectly store itself, thus leading to an infinite recursion.
The reason we didn't see any infinite loops is due to bugs when
resolving types. Fixing these, I managed to hang the compiler instead.

Here are some example programs exposing bugs in the current master,
which is fixed in this commit:

```
trait T<v>

passive class C<v> : T<v>
  f : C<int>
  def foo() : void
    this.f = new C<int>
```

Gives the error `Type 'C<int>' does not match expected type 'C<int>'` on
the last line. This is the bug that lead to this refactoring.

```
trait T<v>

passive class C : T<int, bool, string>
```

Compiles without complaining about the different number of type parameters.

```
passive class C : C
```

Crashes with the error `encorec: Maybe.fromJust: Nothing`

```
trait T<v>

passive class C<v> : T<C<v>>

class Main
  def main() : void
    let x = new C<int> : T<C<int>>
    in
      ()
```

Gives the error `Type 'C<int>' does not match expected type 'T<C<int>>'`
for the typecast in `main` (even though its a subtype). Will also hang
compilation if types are resolved properly.

Since we do not store capability information in the class types anymore,
checking for subtypes requires a lookup, which in turn means that
`isSubtypeOf` needs to be monadic. It has thus been moved to
`Typechecker.Util`, and has been extended to cover more cases. The
subtype checks in `CodeGen.Expr` has been simplified to
`ty /= expected`, optimistically trusting the typechecker that if two
types doesn't exactly match, it's safe to cast one into the other.

This commit also adds a verbatim mode to `encorec` (`-v`) that prints
the compiler phases before running them (useful for bug hunting, and
should probably be extended to become even more verbatimy in the
future).

It also captures the type constraints
`(MonadError TCError m, MonadReader Environment m)` in a type
`TypecheckM a`, meaning the type of all typechecking functions is now of
the form `Foo -> TypecheckM Bar` (where `Bar` is what the function
returns if there are no exceptions). This trick requires the ghc
extension `Rank2Types`, which has been added to the cabal file.
