### PR TITLE
fix #218

### DIFF
--- a/src/types/Typechecker/Environment.hs
+++ b/src/types/Typechecker/Environment.hs
@@ -91,7 +91,7 @@ pushBT x env@Env{bt} = env{bt = push x bt}
 
 backtrace = bt
 
-currentMethod :: Environment -> MethodDecl
+currentMethod :: Environment -> Maybe MethodDecl
 currentMethod = currentMethodFromBacktrace . bt
 
 fieldLookup :: Type -> Name -> Environment -> Maybe FieldDecl

--- a/src/types/Typechecker/TypeError.hs
+++ b/src/types/Typechecker/TypeError.hs
@@ -53,16 +53,11 @@ type Backtrace = [(SourcePos, BacktraceNode)]
 emptyBT :: Backtrace
 emptyBT = []
 
-currentMethodFromBacktrace :: Backtrace -> MethodDecl
-currentMethodFromBacktrace [] =
-  let
-    err = unlines
-      [
-        "*** Internal error ***",
-        "to get current method when not in a method"
-      ]
-  in error err
-currentMethodFromBacktrace ((_, BTMethod m):_) = m
+currentMethodFromBacktrace :: Backtrace -> Maybe MethodDecl
+currentMethodFromBacktrace [] = Nothing
+currentMethodFromBacktrace ((_, BTExpr Closure{}):_) = Nothing
+currentMethodFromBacktrace ((_, BTExpr Async{}):_) = Nothing
+currentMethodFromBacktrace ((_, BTMethod m):_) = Just m
 currentMethodFromBacktrace (_:bt) = currentMethodFromBacktrace bt
 
 -- | A type class for unifying the syntactic elements that can be pushed to the


### PR DESCRIPTION
This commit fixes a bug where checking the current method when not in a
method would crash the compiler. I had this fixed in a local branch, but
not in master...
