### PR TITLE
add cabal-1.22 as dependency

### DIFF
--- a/mylittlepony.cabal
+++ b/mylittlepony.cabal
@@ -14,7 +14,7 @@ maintainer:          tobias.wrigstad@gmail.com
 category:            Language
 build-type:          Simple
 extra-source-files:  README.md
-cabal-version:       >=1.10
+cabal-version:       >=1.22
 
 executable encorec
   main-is:             TopLevel.hs


### PR DESCRIPTION
ghc-7.10.2 requires version 1.22 of cabal. this is a hard requirement that needs to be satisfied. if not, you cannot build the compiler. i believe it's better to be consistent and explicit about this requirement.

If you are a new user, this is not a problem. If you are not, updating `cabal` using `cabal install cabal-install` might not update `cabal`. My problem was that I installed `cabal` using `brew`. Running `cabal install cabal-install` never seemed to update `cabal` to the new version and I couldn't build the compiler.

By forcing the version, it throws an error that tells you to update `cabal`
