### PR TITLE
fix 234, fix 236, bugs related to parametric types

### DIFF
--- a/src/ir/AST/AST.hs
+++ b/src/ir/AST/AST.hs
@@ -200,6 +200,16 @@ isMainMethod ty name = isMainType ty && (name == Name "main")
 isConstructor :: MethodDecl -> Bool
 isConstructor m = mname m == Name "_init"
 
+replaceMethodTypes :: [(Type, Type)] -> MethodDecl -> MethodDecl
+replaceMethodTypes bindings m =
+    let mparams' = map (replaceParamType bindings) (mparams m)
+        mtype' = replaceTypeVars bindings (mtype m)
+    in
+      m{mparams = mparams', mtype = mtype'}
+    where
+      replaceParamType bindings p@Param{ptype} =
+          p{ptype = replaceTypeVars bindings ptype}
+
 instance Eq MethodDecl where
   a == b = mname a == mname b
 

--- a/src/types/Typechecker/Typechecker.hs
+++ b/src/types/Typechecker/Typechecker.hs
@@ -794,9 +794,7 @@ instance Checkable Expr where
              tcError $ "Cannot create an object of type '" ++ show ty ++ "'"
       when (isMainType ty') $
            tcError "Cannot create additional Main objects"
-      bindings <- formalBindings ty'
-      let ty'' = replaceTypeVars bindings ty'
-      return $ setType ty'' new{ty = ty''}
+      return $ setType ty' new{ty = ty'}
 
    ---  |- ty
     --  classLookup(ty) = _


### PR DESCRIPTION
The problem causing 234 was that methods from included traits did not
have their type parameters instantiated when being looked up.

The problem causing 236 was a weird call to `replaceTypeVars` when
typechecking `new`.
