### PR TITLE
fix: add `extern` to global variable in range.h

### DIFF
--- a/src/runtime/range/range.h
+++ b/src/runtime/range/range.h
@@ -16,5 +16,5 @@ size_t  range_start (range_t *a);
 size_t  range_stop  (range_t *a);
 int64_t range_step  (range_t *a);
 
-pony_type_t range_type;
+extern pony_type_t range_type;
 #endif


### PR DESCRIPTION
add missing `extern` keyword when declaring a global variable in `range.h`.
