### PR TITLE
Fix #256, Improve checking for null type

### DIFF
--- a/src/tests/encore/basic/null.enc
+++ b/src/tests/encore/basic/null.enc
@@ -1,0 +1,20 @@
+def foo() : Foo{
+  let x = 42 in
+    while x < 0 {
+      x = x - 1;
+      null;
+    }
+  }
+
+class Foo
+
+class Main
+  def main() : void
+    let x = null : Foo
+        y = Just (null : Foo)
+        f = \ () -> null : Foo
+    in {
+      null : Foo;
+      x = foo();
+      print("I ain't scared of no null!\n");
+    }

--- a/src/tests/encore/basic/null.out
+++ b/src/tests/encore/basic/null.out
@@ -1,0 +1,1 @@
+I ain't scared of no null!


### PR DESCRIPTION
This commit should fix most cases where the null type leaks to the
backend (which causes a crash) by catching it in the typechecker
instead. It generalizes checking for `null` by introducing an auxilary
function `typecheckNotNull` which is called when an expression is used
where no additional type information could coerce the null type to a
reference type (for example the right hand sides of the declarations of
a let or the body of a closure). It unifies all earlier error messages
of type "Cannot infer type of null valued expression".

It's usage is not always obvious. For example, when typechecking a
sequence, all expressions but the last should be checked for the null
type, but the last one should not, as it's actual type could be inferred
from the context of the sequence.

There is also added support for propagating an inferred result type. For
example, in the function

```
def foo() : Foo{
  let x = 42 in
    while x < 0 {
      x = x - 1;
      null;
    }
  }
```

we know that the `null` should be a `Foo` from the result type.
