### PR TITLE
remove unused function in future api

### DIFF
--- a/src/runtime/future/future.c
+++ b/src/runtime/future/future.c
@@ -176,15 +176,6 @@ bool future_fulfilled(future_t *fut)
   return r;
 }
 
-encore_arg_t future_read_value(future_t *fut)
-{
-  perr("future_read_value");
-  BLOCK;
-  encore_arg_t v = fut->value;
-  UNBLOCK;
-  return v;
-}
-
 void future_fulfil(future_t *fut, encore_arg_t value)
 {
   assert(fut->fulfilled == false);
@@ -288,9 +279,6 @@ encore_arg_t future_get_actor(future_t *fut)
   acquire_future_value(fut);
 
   return fut->value;
-
-  // /// TODO: in this case, we need to run future_gc_recv_value() too!
-  // return run_closure(fut->closure, future_read_value(fut->parent), fut);
 }
 
 future_t  *future_chain_actor(future_t *fut, future_t* r, closure_t *c)

--- a/src/runtime/future/future.h
+++ b/src/runtime/future/future.h
@@ -14,7 +14,6 @@ pony_type_t *future_get_type(future_t *fut);
 // ===============================================================
 future_t    *future_mk(pony_type_t *type);
 bool         future_fulfilled  (future_t *fut);
-encore_arg_t future_read_value (future_t *fut);
 void         future_fulfil     (future_t *fut, encore_arg_t value);
 
 // ===============================================================


### PR DESCRIPTION
removed unused function in **future api**. 
no one has used this function since last February. Unless someone plans on using it, I think it should be removed.
