### PR TITLE
Fix calling required extractors through traits

### DIFF
--- a/src/tests/encore/basic/trait-extractor.enc
+++ b/src/tests/encore/basic/trait-extractor.enc
@@ -1,0 +1,21 @@
+trait Result<b>
+  require Success() : Maybe b
+  def Fail() : Maybe int
+    Nothing
+
+passive class Success<b> : Result<b>
+  data : b
+  def init(data : b) : void
+    this.data = data
+
+  def Success() : Maybe b
+    Just this.data
+
+class Main
+  foo : Result<int>
+  def main() : void {
+    this.foo = new Success<int>(5);
+    match this.foo with
+      Fail(n) => print("This shouldn't happen!")
+      Success(x) => print("It's a success! The resulting value is {}\n", x)
+  }

--- a/src/tests/encore/basic/trait-extractor.out
+++ b/src/tests/encore/basic/trait-extractor.out
@@ -1,0 +1,1 @@
+It's a success! The resulting value is 5


### PR DESCRIPTION
The following program generated faulty C-code:

```
trait Result<b> {
  require Success() : Maybe b
}
passive class Success<b> : Result<b> {
  data : b
  def init(data : b) : void {
    this.data = data
  }
  def Success() : Maybe b {
    Just this.data
  }
}
class Main {
  foo : Result<int>
  def main() : void {
    this.foo = new Success<int>(5);
    match this.foo with
      Success(x) => print("It's a success! The resulting value is {}\n", x)
  }
}
```

The problem was that the extractor code was assuming that the extractor
was a method defined in a class, so it would not work for trait types.
