### PR TITLE
Fix #311

### DIFF
--- a/src/tests/encore/basic/upcast.enc
+++ b/src/tests/encore/basic/upcast.enc
@@ -3,11 +3,11 @@ trait Foo
   def foo() : int
     this.x
 
-trait Bar
+trait Bar<t, u>
   def bar(x : Foo) : int
     x.foo()
 
-passive class C : Foo + Bar
+passive class C<t> : Foo + Bar<int, String>
   x : int
   def init(x : int) : void
     this.x = x
@@ -15,9 +15,10 @@ passive class C : Foo + Bar
 
 class Main
   def main() : void
-    let c = new C(42)
-        x = c : Foo
-        y = c : Bar
+    let c = new C<int>(42)
+        d = c : Foo
+        x = new C<int>(42) : Foo
+        y = new C<int>(42) : Bar<int, String>
     in{
       print y.bar(x);
       print "Done!";


### PR DESCRIPTION
Fixed broken coercion that would lose type parameters when casting:

```
trait T

passive class C<c> : T

class Main
  def main() : void
    let x = new C<int> : T in
      ()
```
