### PR TITLE
Fixed bug regarding String instantiation

### DIFF
--- a/src/ir/AST/Desugarer.hs
+++ b/src/ir/AST/Desugarer.hs
@@ -197,6 +197,12 @@ desugar New{emeta, ty} = NewWithInit{emeta, ty, args = []}
 desugar new@NewWithInit{emeta, ty, args}
     | isArrayType ty &&
       length args == 1 = ArrayNew emeta (getResultType ty) (head args)
+    | singleCapability ty
+    , [refTy] <- typesFromCapability ty
+    , "String" <- getId refTy
+    , [new'@NewWithInit{ty = ty', args = args'}] <- args
+    , isStringObjectType ty'
+    , length args' == 1 = new'
     | otherwise = new
 
 desugar s@StringLiteral{emeta, stringLit} =

--- a/src/types/Typechecker/Typechecker.hs
+++ b/src/types/Typechecker/Typechecker.hs
@@ -934,15 +934,9 @@ instance Checkable Expr where
       fBindings <- formalBindings ty'
       let paramTypes = map ptype (hparams header)
           expectedTypes = map (replaceTypeVars fBindings) paramTypes
-          args' = if isStringObjectType ty'
-                  then stringArg args
-                  else args
       (eArgs, bindings) <- local (bindTypes fBindings) $
-                                 matchArguments args' expectedTypes
+                                 matchArguments args expectedTypes
       return $ setType ty' new{ty = ty', args = eArgs}
-      where
-        stringArg [NewWithInit{args}] = args
-        stringArg args = args
 
    ---  |- ty
     --  classLookup(ty) = _


### PR DESCRIPTION
@albertnetymk suggested a refactoring of how Strings are instantiated,
which leaves the work of turning string literals into constructor calls
completely to the desugarer, leaving the typechecker oblivious to the
existence of two different kind of strings (C-level strings and
Encore-level strings). In the process, a bug was discovered and
squished:

```
class T

class Main {
  def main() : void {
    new String("foo");
    new String(new T); -- Crashes the compiler
  }
}
```
