### PR TITLE
add github templates for PR and Issues

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,6 @@
+Make sure the following boxes are checked before creating an issue:
+
+- [] State the problem
+- [] Specify the compiler's branch and make sure it is on top of `development`
+- [] Use a Github label if possible
+- [] Try to provide a minimal example that reproduces the error

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+Make sure these boxes are checked before submitting your pull request:
+
+- [] Description of the pull request stating the problem and the solution
+- [] Tests (if applicable)
+- [] Documentation (if applicable)


### PR DESCRIPTION
add github templates for PR and issues. this will remind us of small mistakes, such as not providing tests in new PRs, not updating the docs, etc.
