### PR TITLE
Fixed closure import problem when defining a library #336

### DIFF
--- a/src/tests/encore/modules/ClosureImp.enc
+++ b/src/tests/encore/modules/ClosureImp.enc
@@ -1,0 +1,3 @@
+class Foo
+  def bar() : void
+    \() -> print "ClosureImp"

--- a/src/tests/encore/modules/ClosureImporter.enc
+++ b/src/tests/encore/modules/ClosureImporter.enc
@@ -1,0 +1,5 @@
+import ClosureImp
+
+class Main
+  def main() : void
+    print ((new Foo).bar())

--- a/src/tests/encore/modules/ClosureImporter.out
+++ b/src/tests/encore/modules/ClosureImporter.out
@@ -1,0 +1,1 @@
+ClosureImp


### PR DESCRIPTION
We have fixed this problem by adding more cases to due with `import` in `Utils.hs`

``` Haskell
extendAccumProgram f acc0 p@Program{functions, traits, classes, imports} =
  (acc4, p{functions = funs', traits = traits', classes = classes', imports = imports'})

      .......
      (acc4, imports') = List.mapAccumL (extendAccumImport f) acc3 imports
      extendAccumImport f acc i@(PulledImport{iprogram}) =
        (acc', i{iprogram = iprogram'})
        where
          (acc', iprogram') = extendAccumProgram f acc iprogram
      extendAccumImport _ _ _ = error "Util.hs: Non desugared imports during extendAccumProgram"
```
