### PR TITLE
fix #295: tracing parametric fields

### DIFF
--- a/src/back/CodeGen/Type.hs
+++ b/src/back/CodeGen/Type.hs
@@ -50,7 +50,12 @@ runtimeType ty
     | Ty.isArrayType ty  = Amp arrayTypeRecName
     | Ty.isRangeType ty  = Amp rangeTypeRecName
     | Ty.isParType ty    = Amp partyTypeRecName
+    | Ty.isPrimitive ty  = AsExpr $ Var "ENCORE_PRIMITIVE"
     | otherwise = AsExpr $ Var "ENCORE_PRIMITIVE"
+
+getRuntimeTypeVariables t
+  | Ty.isTypeVar t =  AsExpr $ (Var "_this") `Arrow` typeVarRefName t
+  | otherwise = runtimeType t
 
 encoreArgTTag :: CCode Ty -> CCode Name
 encoreArgTTag (Ptr _)         = Nam "p"


### PR DESCRIPTION
Parametric classes that pass their type variables to create new instances of other classes where being traced as `ENCORE_PRIMITIVE`. This commit fixes this issue when creating new classes and for the creation of arrays.
- Branch: `development`
- Example:

```
passive class Test<a>

  def init(): void
    ()

  def tt(x: a): void {
    new Test<a>();
    new [a](10);
  }

class Main
  def main(): void
    ()
```

This example uses the runtime types when creating new object instances of parametric types. This is the emitted C code, where `_enc__type_init_Test(_new_0, _this->_enc__type_a);` refers to the runtime type as well as this other one `array_t* _array_1 = array_mk(_literal_3, _this->_enc__type_a);`:

```
void* _enc__method_Test_tt(_enc__passive_Test_t* _this, encore_arg_t _enc__arg_x)
{
  /* new Test<a>() */;
  _enc__passive_Test_t* _new_0 = encore_alloc(sizeof(_enc__passive_Test_t));
  _new_0->_enc__self_type = (&(_enc__passive_Test_type));
  _enc__type_init_Test(_new_0, _this->_enc__type_a);
  _enc__method_Test__init(_new_0);
  /* new [a](10) */;
  int64_t _literal_3 = 10;
  array_t* _array_1 = array_mk(_literal_3, _this->_enc__type_a);
  return UNIT;
}
```
