### PR TITLE
fix compile error in `each` combinator

### DIFF
--- a/src/front/TopLevel.hs
+++ b/src/front/TopLevel.hs
@@ -131,7 +131,7 @@ compileProgram prog sourcePath options =
            sharedFile = srcDir </> "shared.c"
            makefile   = srcDir </> "Makefile"
            cc    = "clang"
-           flags = "-std=gnu11 -ggdb -Wall -fms-extensions -Wno-format -Wno-microsoft -Wno-parentheses-equality -Wno-unused-variable -Wno-unused-value -lpthread -Wno-attributes"
+           flags = "-std=gnu11 -ggdb -Wall -fms-extensions -Wno-format -Wno-microsoft -Wno-parentheses-equality -Wno-unused-variable -Wno-unused-value -lpthread -lm -Wno-attributes"
            oFlag = "-o" <+> execName
            incs  = "-I" <+> incPath <+> "-I ."
            pg = if (Profile `elem` options) then "-pg" else ""

--- a/src/tests/encore/par/Makefile
+++ b/src/tests/encore/par/Makefile
@@ -1,8 +1,12 @@
 ROOT_PATH=../../../..
 ENCOREC=$(ROOT_PATH)/release/encorec
 
-#ENCORE_SOURCES=$(shell ls *.enc)
-ENCORE_SOURCES=each.enc extract.enc general.enc liftf.enc liftv.enc sequence.enc
+ENCORE_SOURCES+=each.enc
+ENCORE_SOURCES+=extract.enc
+ENCORE_SOURCES+=general.enc
+ENCORE_SOURCES+=liftf.enc
+ENCORE_SOURCES+=liftv.enc
+ENCORE_SOURCES+=sequence.enc
 ENCORE_TARGETS=$(ENCORE_SOURCES:.enc=)
 
 all: test

--- a/src/tests/encore/par/each.enc
+++ b/src/tests/encore/par/each.enc
@@ -9,8 +9,14 @@ class Main
     for v in [0..this.size] this.check_arr[v] = false;
   }
 
-  def all(): void
+  def assert_all(): void
     for v in this.check_arr assertTrue(v, "Expected 'true' value in test")
+
+  def assert_limits(): void {
+    assertTrue(this.check_arr[0], "Expected 'true' value in array with index: 0");
+    assertTrue(this.check_arr[this.size],
+               "Exprected 'true' value in array with index: {}", this.size);
+  }
 
   def main(): void {
     this.setup();
@@ -19,7 +25,12 @@ class Main
         size = this.size
     in {
         for i in rng arr[i] = i;
+
+        -- synchronisation primitive:
+        -- block until all items in Par have run the callback
         extract(each(arr) >> \(i: int) -> this.check_arr[i] = true);
-        this.all();
+
+        this.assert_limits();
+        this.assert_all();
         };
   }


### PR DESCRIPTION
add -lm flag to make the party.\* compile and add tests cases to test the
values on the limits of the array
