### PR TITLE
Fix #364

### DIFF
--- a/src/tests/encore/basic/functionCast.enc
+++ b/src/tests/encore/basic/functionCast.enc
@@ -1,0 +1,11 @@
+def fun() : (String, String) {
+  ("Hello", "world")
+}
+
+class Main {
+  def main() : void {
+    let foo = fun : () -> (String, String);
+    match foo() with
+      (h, w) => print("{} {}\n", h, w)
+  }
+}

--- a/src/tests/encore/basic/functionCast.out
+++ b/src/tests/encore/basic/functionCast.out
@@ -1,0 +1,1 @@
+Hello world

--- a/src/types/Types.hs
+++ b/src/types/Types.hs
@@ -375,7 +375,7 @@ typeMapM f ty@CapabilityType{capability} = do
   f ty{capability = capability'}
 typeMapM f ty@ArrowType{argTypes, resultType} = do
   argTypes' <- mapM (typeMapM f) argTypes
-  resultType' <- f resultType
+  resultType' <- typeMapM f resultType
   f ty{argTypes = argTypes'
       ,resultType = resultType'}
 typeMapM f ty@TupleType{argTypes} = do


### PR DESCRIPTION
The monadic map over types did not properly recurse for the result type
of an arrow type (it called `f result` rather than `typeMapM f result`). This
caused the following program to not compile (added as test):

```
def fun() : (String, String) {
  ("Hello", "world")
}

class Main {
  def main() : void {
    let foo = fun : () -> (String, String);
    match foo() with
      (h, w) => print("{} {}\n", h, w)
  }
}
```
