### PR TITLE
Added support for promoting `int` to `real`

### DIFF
--- a/src/tests/encore/basic/real.enc
+++ b/src/tests/encore/basic/real.enc
@@ -1,5 +1,9 @@
+def foo(x : real) : real
+  x
+
 class Main
-  def main() : void
-    let pi = 3.141593 in
-      {print "Pi is something like ";
-       print pi}
+  def main() : void {
+    let pi = 3.141593;
+    print("Pi is something like {}\n", pi);
+    print("Ints can be promoted to reals: {}\n", foo(42))
+  }

--- a/src/tests/encore/basic/real.out
+++ b/src/tests/encore/basic/real.out
@@ -1,2 +1,2 @@
-Pi is something like 
-3.141593
+Pi is something like 3.141593
+Ints can be promoted to reals: 42.000000

--- a/src/types/Typechecker/Util.hs
+++ b/src/types/Typechecker/Util.hs
@@ -150,6 +150,8 @@ subtypeOf ty1 ty2
     | isCapabilityType ty1 && isCapabilityType ty2 =
         ty1 `capabilitySubtypeOf` ty2
     | isBottomType ty1 && (not . isBottomType $ ty2) = return True
+    | isNumeric ty1 && isNumeric ty2 =
+        return $ ty1 `numericSubtypeOf` ty2
     | otherwise = return (ty1 == ty2)
     where
       refSubtypeOf ref1 ref2
@@ -165,6 +167,10 @@ subtypeOf ty1 ty2
         let traits1 = typesFromCapability cap1
             traits2 = typesFromCapability cap2
         allM (\t2 -> anyM (`subtypeOf` t2) traits1) traits2
+
+      numericSubtypeOf ty1 ty2
+          | isIntType ty1 && isRealType ty2 = True
+          | otherwise = ty1 == ty2
 
 -- | Convenience function for asserting distinctness of a list of
 -- things. @assertDistinct "declaration" "field" [f : Foo, f :


### PR DESCRIPTION
This is implemented by making `int` a subtype of `real` and letting C
handle the actual conversion. The test case `real.enc` has been updated.
