### PR TITLE
Added to_int, is_int and string_from_int

### DIFF
--- a/bundles/standard/String.enc
+++ b/bundles/standard/String.enc
@@ -3,6 +3,7 @@ embed
 #include <strings.h>
 #include <alloca.h>
 #include <ctype.h>
+#include <math.h>
 array_t *_init_argv(pony_ctx_t* ctx, size_t argc, char **argv);
 body
 array_t *_init_argv(pony_ctx_t* ctx, size_t argc, char **argv) {
@@ -34,6 +35,18 @@ def string_from_array(arr : [char]) : String
       embed void *#{p}++ = #{c}; end;
     new String(s)
   }
+
+def string_from_int(n : int) : String
+  new String(embed
+    (embed char* end)
+    int n = #{n};
+    int len = n < 0? (int) ceil(log10(-n)) + 2:
+                     (int) ceil(log10(n)) + 1;
+    char *s = encore_alloc(_ctx, len);
+    sprintf(s, "%d", n);
+    s;
+    end
+  )
 
 -- This is a utility library for working with strings.
 -- [x] build a wrapper around string.h
@@ -320,3 +333,21 @@ passive class String
         result[occurrences] = match this.substring(start, this.length()) with Just s => s;
         result;
       }
+
+  def to_int() : Maybe int {
+    let s = this.data;
+    let n = 0;
+    let success = false;
+    embed void
+      char *s = #{s};
+      char *endptr;
+      #{n} = strtol(s,&endptr,0);
+      if (s != endptr)
+         #{success} = true;
+    end;
+    if success then {
+      Just n;
+    } else {
+      Nothing : Maybe int
+    }
+  }

--- a/src/tests/encore/Makefile
+++ b/src/tests/encore/Makefile
@@ -1,13 +1,15 @@
-test: 
+test:
 	make -C basic clean test
 	make -C concurrency clean test
 	make -C par clean test
 	make -C modules clean test
+	make -C stdlib clean test
 
 clean:
 	make -C basic clean
 	make -C concurrency clean
 	make -C par clean
 	make -C modules clean
+	make -C stdlib clean
 
 .PHONY: test clean $(TEST_DIRECTORY)

--- a/src/tests/encore/stdlib/Makefile
+++ b/src/tests/encore/stdlib/Makefile
@@ -1,0 +1,16 @@
+ROOT_PATH=../../../..
+ENCOREC=${ROOT_PATH}/release/encorec
+
+TESTS = string
+
+test: $(TESTS)
+
+%: %.enc
+	$(ENCOREC) $<
+	./$@
+
+clean:
+	rm -f $(TESTS)
+	rm -rf *.dSYM
+
+.PHONY: clean test

--- a/src/tests/encore/stdlib/string.enc
+++ b/src/tests/encore/stdlib/string.enc
@@ -79,6 +79,10 @@ passive class Test
     print "From array passed";
     this.test_from_char();
     print "From char passed";
+    this.test_string_from_int();
+    print "String from int passed";
+    this.test_to_int();
+    print "To int passed";
     print "================";
     print "All tests passed";
     print "================";
@@ -314,3 +318,33 @@ passive class Test
       s = string_from_char('A')
     in
       assertTrue(s.equals("A"))
+
+  def test_string_from_int() : void
+    let
+      s1 = string_from_int(123456789)
+      s2 = string_from_int(-42)
+    in {
+      assertTrue(s1.equals("123456789"));
+      assertTrue(s2.equals("-42"));
+    }
+
+  def test_to_int() : void
+    let
+      s1 = "42"
+      s2 = "-42"
+      s3 = "foobar"
+      s4 = "0x10xyz"
+    in {
+      assertTrue(match s1.to_int() with
+                   Just n => n == 42
+                   Nothing => false);
+      assertTrue(match s2.to_int() with
+                   Just n => n == -42
+                   Nothing => false);
+      assertTrue(match s3.to_int() with
+                   Just n => false
+                   _ => true);
+      assertTrue(match s4.to_int() with
+                   Just n => n == 16
+                   Nothing => false);
+    }


### PR DESCRIPTION
This commit extends the String library with support for translating
to and from ints. Tests in `src/tests/encore/stdlib/string.enc` have 
been extended.
