### PR TITLE
Compilation terminates whith unknown flags.

### DIFF
--- a/doc/encore/lang/introduction/introduction.scrbl
+++ b/doc/encore/lang/introduction/introduction.scrbl
@@ -44,7 +44,7 @@ Running @code{encorec foo.enc} will typecheck the source and produce the executa
 @item{@code{-clang} -- Use clang to build the executable (default)}
 @item{@code{-AST} -- Output the parsed AST as text to foo.AST}
 @item{@code{-TypedAST} -- Output the typechecked AST as text to foo.TAST}
-@item{@code{-nogc} -- Disables the garbage collection of passive objects.}
+@item{@code{-nogc} -- Disable the garbage collection of passive objects.}
 @item{@code{-help} -- Prints a help message and then exits.}
 @item{@code{-I path1:path2:...} -- Directories in which to look for modules. (Not needed for modules which are in the current folder.)}
 ]

--- a/src/front/TopLevel.hs
+++ b/src/front/TopLevel.hs
@@ -109,7 +109,7 @@ checkForUndefined options =
       mapM (\flag -> case flag of
               Undefined flag -> 
                 abort $ "Unknown flag " <> flag <> 
-                ". Use -help to se avaliable flags."
+                ". Use -help to see available flags."
               _ -> return ()) options
 
 output :: Show a => a -> Handle -> IO ()
@@ -248,19 +248,19 @@ main =
       addStdLib ast@Program{imports = i} = ast{imports = i ++ stdLib}
       -- TODO: move this elsewhere
       stdLib = [Import (Meta.meta (P.initialPos "String.enc")) (Name "String" : [])]
-     
+
       showWarnings = mapM print
       helpMessage = 
         "Welcome to the Encore compiler!\n" <>
         usage <> "\n\n" <>
         "Flags:\n" <>
-        "  -c           Keep intermediate C-files\n" <>
-        "  -tc          Typecheck only (don't produce an executable)\n" <>
-        "  -o [file]    Specify output file\n" <>
-        "  -run         Run the program and remove the executable\n" <>
-        "  -clang       Use clang to build the executable (default)\n" <>
-        "  -AST         Output the parsed AST as text to foo.AST\n" <>
-        "  -TypedAST    Output the typechecked AST as text to foo.TAST\n" <>
-        "  -nogc        Disables the garbage collection of passive objects.\n" <>
+        "  -c           Keep intermediate C-files.\n" <>
+        "  -tc          Typecheck only (don't produce an executable).\n" <>
+        "  -o [file]    Specify output file.\n" <>
+        "  -run         Run the program and remove the executable.\n" <>
+        "  -clang       Use clang to build the executable (default).\n" <>
+        "  -AST         Output the parsed AST as text to foo.AST.\n" <>
+        "  -TypedAST    Output the typechecked AST as text to foo.TAST.\n" <>
+        "  -nogc        Disable the garbage collection of passive objects.\n" <>
         "  -help        Print this message and exit.\n" <>
         "  -I p1:p2:... Directories in which to look for modules."


### PR DESCRIPTION
Compilation now fails when unknown flags are provided.
Ex:
`encorec -blah test.enc`
outputs
`Unknown flag bla. Use -help to se avaliable flags.`

A `-help` flag is available that outputs:

```
Welcome to the Encore compiler!
Usage: encorec [flags] file

Flags:
  -c           Keep intermediate C-files
  -tc          Typecheck only (don't produce an executable)
  -o [file]    Specify output file
  -run         Run the program and remove the executable
  -clang       Use clang to build the executable (default)
  -AST         Output the parsed AST as text to foo.AST
  -TypedAST    Output the typechecked AST as text to foo.TAST
  -nogc        Disables the garbage collection of passive objects.
  -help        Print this message and exit.
  -I p1:p2:... Directories in which to look for modules.
```
