### PR TITLE
Improved printing support

### DIFF
--- a/src/back/CCode/Main.hs
+++ b/src/back/CCode/Main.hs
@@ -90,6 +90,7 @@ data CCode a where
     While        :: CCode Expr -> CCode Stat -> CCode Stat
     StatAsExpr   :: CCode Lval -> CCode Stat -> CCode Expr
     If           :: UsableAs e Expr => CCode e -> CCode Stat -> CCode Stat -> CCode Expr
+    Ternary      :: UsableAs e Expr => CCode e -> CCode Expr -> CCode Expr -> CCode Expr
     Return       :: UsableAs e Expr => CCode e -> CCode Stat
     UnionInst    :: UsableAs e Expr => CCode Name -> CCode e -> CCode Expr
     Int          :: Int -> CCode Expr

--- a/src/back/CCode/PrettyCCode.hs
+++ b/src/back/CCode/PrettyCCode.hs
@@ -107,6 +107,7 @@ pp' (If c t e) = text "if" <+> parens  (pp' c) $+$
                    bracedBlock (pp' t) $+$
                  text "else" $+$
                    bracedBlock (pp' e)
+pp' (Ternary c t e) = pp' c <> text "?" <+> pp' t <> text ":" <+> pp' e
 pp' (Return e) = text "return" <+> pp' e <> text ";"
 pp' (UnionInst name e) = text "{." <> tshow name <+> text "=" <+> pp' e <> text "}"
 pp' (Int n) = tshow n

--- a/src/ir/AST/Desugarer.hs
+++ b/src/ir/AST/Desugarer.hs
@@ -55,6 +55,12 @@ desugar seq@Seq{eseq} = seq{eseq = expandMiniLets eseq}
 
 desugar FunctionCall{emeta, name = Name "exit", args} = Exit emeta args
 
+desugar FunctionCall{emeta, name = Name "print", args = []} =
+    Print emeta [StringLiteral emeta "\n"]
+
+desugar FunctionCall{emeta, name = Name "print", args = [arg]} =
+    Print emeta [StringLiteral emeta "{}\n", arg]
+
 desugar FunctionCall{emeta, name = Name "print", args} =
     Print emeta args
 
@@ -84,13 +90,10 @@ desugar FunctionCall{emeta, name = Name "assertTrue", args = cond : rest} =
            (Seq (cloneMeta emeta)
                 [Print (cloneMeta emeta)
                        [selfSugar $ StringLiteral (cloneMeta emeta)
-                                                  "{}Assertion failed: ",
-                        selfSugar $ StringLiteral (cloneMeta emeta) ""], -- Suppress newline
+                                                  "Assertion failed: "],
                  Print (cloneMeta emeta) rest,
-                 if length rest > 1 then
-                     Print (cloneMeta emeta) [] -- Add newline
-                 else
-                     Skip (cloneMeta emeta),
+                 Print (cloneMeta emeta)
+                       [selfSugar $ StringLiteral (cloneMeta emeta) "\n"],
                  Exit (cloneMeta emeta) [IntLiteral (cloneMeta emeta) 1]])
 
 desugar FunctionCall{emeta, name = Name "assertFalse", args = cond : rest} =
@@ -98,13 +101,10 @@ desugar FunctionCall{emeta, name = Name "assertFalse", args = cond : rest} =
            (Seq (cloneMeta emeta)
                 [Print (cloneMeta emeta)
                        [selfSugar $ StringLiteral (cloneMeta emeta)
-                                                  "{}Assertion failed: ",
-                        selfSugar $ StringLiteral (cloneMeta emeta) ""],
+                                                  "Assertion failed: "],
                  Print (cloneMeta emeta) rest,
-                 if length rest > 1 then
-                     Print (cloneMeta emeta) [] -- Add newline
-                 else
-                     Skip (cloneMeta emeta),
+                 Print (cloneMeta emeta)
+                       [selfSugar $ StringLiteral (cloneMeta emeta) "\n"],
                  Exit (cloneMeta emeta) [IntLiteral (cloneMeta emeta) 1]])
            (Skip (cloneMeta emeta))
 

--- a/src/parser/Parser/Parser.hs
+++ b/src/parser/Parser/Parser.hs
@@ -723,7 +723,7 @@ expr  =  unit
       print = do pos <- getPosition
                  reserved "print"
                  arg <- option [] ((:[]) <$> expression)
-                 return $ Print (meta pos) arg
+                 return $ FunctionCall (meta pos) (Name "print") arg
       stringLit = do pos <- getPosition
                      string <- stringLiteral
                      return $ StringLiteral (meta pos) string

--- a/src/runtime/range/range.c
+++ b/src/runtime/range/range.c
@@ -5,8 +5,8 @@
 
 struct range_t
 {
-  size_t start;
-  size_t stop;
+  int64_t start;
+  int64_t stop;
   int64_t step;
 };
 
@@ -22,7 +22,8 @@ void range_trace(pony_ctx_t* ctx, void *p)
   // No pointers
 }
 
-struct range_t *range_mk(pony_ctx_t* ctx, size_t start, size_t stop, int64_t step)
+struct range_t *range_mk(pony_ctx_t* ctx, int64_t start,
+                         int64_t stop, int64_t step)
 {
   ctx = pony_ctx();
   range_assert_step(step);
@@ -40,6 +41,6 @@ void range_assert_step(int64_t step)
     }
 }
 
-size_t  range_start (struct range_t *a) { return a->start; }
-size_t  range_stop  (struct range_t *a) { return a->stop;  }
+int64_t  range_start (struct range_t *a) { return a->start; }
+int64_t  range_stop  (struct range_t *a) { return a->stop;  }
 int64_t range_step  (struct range_t *a) { return a->step;  }

--- a/src/runtime/range/range.h
+++ b/src/runtime/range/range.h
@@ -8,12 +8,12 @@ typedef struct range_t range_t;
 
 void range_trace(pony_ctx_t*, void *);
 
-range_t *range_mk(pony_ctx_t* ctx, size_t start, size_t stop, int64_t step);
+range_t *range_mk(pony_ctx_t* ctx, int64_t start, int64_t stop, int64_t step);
 
 void range_assert_step(int64_t step);
 
-size_t  range_start (range_t *a);
-size_t  range_stop  (range_t *a);
+int64_t range_start (range_t *a);
+int64_t range_stop  (range_t *a);
 int64_t range_step  (range_t *a);
 
 extern pony_type_t range_type;

--- a/src/tests/encore/basic/assertFalseMsg.out
+++ b/src/tests/encore/basic/assertFalseMsg.out
@@ -1,1 +1,1 @@
-Assertion failed: Int 42 Bool bool<0> String Foo
+Assertion failed: Int 42 Bool false String Foo

--- a/src/tests/encore/basic/assertTrueMsg.out
+++ b/src/tests/encore/basic/assertTrueMsg.out
@@ -1,1 +1,1 @@
-Assertion failed: Int 42 Bool bool<0> String Foo
+Assertion failed: Int 42 Bool false String Foo

--- a/src/tests/encore/basic/boolean.out
+++ b/src/tests/encore/basic/boolean.out
@@ -1,3 +1,3 @@
-bool<0>
-bool<1>
-bool<0>
+false
+true
+false

--- a/src/tests/encore/basic/for-loop.out
+++ b/src/tests/encore/basic/for-loop.out
@@ -1,8 +1,8 @@
-bool<0>
-bool<0>
-bool<1>
-bool<0>
-bool<1>
+false
+false
+true
+false
+true
 --------------
 1
 3

--- a/src/tests/encore/basic/prefix_test.out
+++ b/src/tests/encore/basic/prefix_test.out
@@ -1,5 +1,5 @@
 blingbling
-bool<0>
-bool<0>
-bool<0>
-bool<1>
+false
+false
+false
+true

--- a/src/tests/encore/basic/printf.enc
+++ b/src/tests/encore/basic/printf.enc
@@ -1,7 +1,15 @@
 class Main
-  def main() : void
-    let i = 1 in
-      while i < 10{
-        print("The square of {} is {}\n", i, i*i);
-        i = i + 1;
+  def main() : void {
+    for i in [1..9] {
+      print("The square of {} is {}\n", i, i*i);
+    };
+    let row = [false, true];
+    for b1 in row {
+      for b2 in row {
+        print("{} | {}\n", (b1, b2), b1 and b2);
       }
+    };
+    print ("void = {}\n", ());
+    print ("Zero is {}\n", Nothing : Maybe int);
+    print ("The answer is {}\n", Just 42);
+  }

--- a/src/tests/encore/basic/printf.out
+++ b/src/tests/encore/basic/printf.out
@@ -7,3 +7,10 @@ The square of 6 is 36
 The square of 7 is 49
 The square of 8 is 64
 The square of 9 is 81
+(false, false) | false
+(false, true) | false
+(true, false) | false
+(true, true) | true
+void = ()
+Zero is Nothing
+The answer is Just 42

--- a/src/tests/encore/par/general.out
+++ b/src/tests/encore/par/general.out
@@ -1,7 +1,7 @@
-bool<1>
-bool<1>
-bool<1>
-bool<1>
-bool<1>
-bool<1>
-bool<1>
+true
+true
+true
+true
+true
+true
+true

--- a/src/types/Types.hs
+++ b/src/types/Types.hs
@@ -81,6 +81,7 @@ module Types(
             ,isBottomType
             ,hasResultType
             ,setResultType
+            ,isPrintable
             ) where
 
 import Data.List
@@ -210,6 +211,8 @@ instance Show Type where
     show ClassType{refInfo} = show refInfo
     show CapabilityType{capability} = show capability
     show TypeVar{ident} = ident
+    show ArrowType{argTypes = [ty], resultType} =
+        show ty ++ " -> " ++ show resultType
     show ArrowType{argTypes, resultType} =
         "(" ++ args ++ ") -> " ++ show resultType
         where
@@ -616,3 +619,11 @@ isPrimitive = (`elem` primitives)
 
 isNumeric :: Type -> Bool
 isNumeric ty = isRealType ty || isIntType ty
+
+isPrintable :: Type -> Bool
+isPrintable ty
+  | isTypeVar ty     = False
+  | isCType ty       = False
+  | hasResultType ty = isPrintable $ getResultType ty
+  | isTupleType ty   = all isPrintable $ getArgTypes ty
+  | otherwise        = True


### PR DESCRIPTION
This commit improves the printing support and fixes #352 and fixes #320.
The following list summarizes the current printing behavior:
- Reference types `T` are printed as `T@0x012345`, where the hexadecimal
  value is the address of the object. The same thing goes for futures,
  streams, arrays and ParT-values. `null` is printed as `T@0x0`.
- Values whose type isn't statically known cannot be printed. This
  includes any polymorphic values.
- Closures cannot be printed.
- Values of embedded types cannot be printed. You can (and should) drop
  down to C if you really need to print such a value (or closures or
  polymorphic values for that matter).
- Ranges are printed as `[1..10 by 1]`. The `by` part is always included
  for simplicity.
- Maybe types are printed like they should, although the generated code
  is a bit nasty. For each maybe type, a string is allocated for the
  sole purpose of being printed. The length of this string is
  approximated by summing approximations of the lengths of all
  subexpressions. Strings use their dynamic lengths and tuples the sum
  of the approximations of their contents. All other lengths are
  approximated as the length of their type plus 30 (compare with how
  reference types are printed). The 30 should be enough to hold any
  addresses, integers or reals. It would be better to calculate a
  maximum depending on the type, but if you're doing things like
  printing `Maybe`s, you probably don't care about performance anyway.
- Tuples are also printed like they should, and since their shape is
  known statically, the code isn't as bad.
- Values of `void` type are always printed as `()`
- Strings, chars, ints, booleans and reals are printed like you would
  expect. The only news here is proper printing of booleans as `true`
  and `false`.

The existing tests already test much of the printing, and some of them
have been updated to align with the new syntax. The test `printf` tests
some of the new printing.

Testing this has reminded me that the lack of proper inference for
`null` and `bottom` is annoying, but fixing this does not belong in this
PR.
