### PR TITLE
Fixed operator precedence

### DIFF
--- a/src/parser/Parser/Parser.hs
+++ b/src/parser/Parser/Parser.hs
@@ -398,15 +398,15 @@ expression = buildExpressionParser opTable highOrderExpr
     where
       opTable = [
                  [arrayAccess],
-                 [textualPrefix "not" Identifiers.NOT],
-                 [textualOperator "and" Identifiers.AND,
-                  textualOperator "or" Identifiers.OR],
                  [prefix "-" NEG],
                  [op "*" TIMES, op "/" DIV, op "%" MOD],
                  [op "+" PLUS, op "-" MINUS],
                  [op "<" Identifiers.LT, op ">" Identifiers.GT,
                   op "<=" Identifiers.LTE, op ">=" Identifiers.GTE,
                   op "==" Identifiers.EQ, op "!=" NEQ],
+                 [textualPrefix "not" Identifiers.NOT],
+                 [textualOperator "and" Identifiers.AND,
+                  textualOperator "or" Identifiers.OR],
                  [messageSend],
                  [partyLiftf, partyLiftv, partyEach],
                  [typedExpression],

--- a/src/tests/encore/basic/operator_precedence.enc
+++ b/src/tests/encore/basic/operator_precedence.enc
@@ -1,0 +1,9 @@
+class Main
+
+  def main() : void {
+    print((123 == 100+23 and 789 <= 888) and ((123 == (100+23)) and (789 <= 888)));
+    print((1+1 == 2 == true or false) and (((1+1 == 2) == true) or false)) ;
+    let a = Just 45;
+    let b = Nothing : Maybe int;
+    print((a != Nothing and b == Nothing) and ((a != Nothing) and (b == Nothing)))
+  }

--- a/src/tests/encore/basic/operator_precedence.out
+++ b/src/tests/encore/basic/operator_precedence.out
@@ -1,0 +1,3 @@
+true
+true
+true


### PR DESCRIPTION
Operator precedence is now normal.
Now equality checks bind stronger than logical operators.

Before one had to write `1 == 2 and 5 <= 2` as `(1 == 2) and ( 5 <= 2 )`

Relates to issue #385
