### PR TITLE
Make sure the String library refreshes context

### DIFF
--- a/bundles/standard/String.enc
+++ b/bundles/standard/String.enc
@@ -6,6 +6,8 @@ embed
 #include <math.h>
 array_t *_init_argv(pony_ctx_t* ctx, size_t argc, char **argv);
 body
+// This function is called in the very beginning of the program to
+// build an array containing the arguments of the program.
 array_t *_init_argv(pony_ctx_t* ctx, size_t argc, char **argv) {
   array_t *arr = array_mk(ctx, argc, &_enc__passive_String_type);
   for(int i = 0; i < argc; i++) {
@@ -21,14 +23,14 @@ end
 
 def string_from_char(c : char) : String
   let
-    s = embed (embed char* end) encore_alloc(_ctx, 2); end
+    s = embed (embed char* end) encore_alloc(encore_ctx(), 2); end
   in
     new String(embed (embed char* end) *#{s} = #{c}; #{s}; end)
 
 def string_from_array(arr : [char]) : String
   let
     len = |arr|
-    s = embed (embed char* end) encore_alloc(_ctx, #{len} + 1); end
+    s = embed (embed char* end) encore_alloc(encore_ctx(), #{len} + 1); end
     p = s
   in{
     for c in arr
@@ -42,7 +44,7 @@ def string_from_int(n : int) : String
     int n = #{n};
     int len = n < 0? (int) ceil(log10(-n)) + 2:
                      (int) ceil(log10(n)) + 1;
-    char *s = encore_alloc(_ctx, len);
+    char *s = encore_alloc(encore_ctx(), len);
     sprintf(s, "%d", n);
     s;
     end
@@ -78,7 +80,7 @@ passive class String
       b_data = b.data
     in
       new String(embed (embed char* end)
-        void *str = encore_alloc(_ctx, #{t_len} + #{b_len} + 1);
+        void *str = encore_alloc(encore_ctx(), #{t_len} + #{b_len} + 1);
         strncpy(str, (char *)#{t_data}, #{t_len});
         strncat(str, (char *)#{b_data}, #{b_len});
         str;
@@ -90,7 +92,7 @@ passive class String
       data  = this.data
     in
       new String(embed (embed char* end)
-        char *str = encore_alloc(_ctx, #{t_len} + 1);
+        char *str = encore_alloc(encore_ctx(), #{t_len} + 1);
         strncpy(str, (char *)#{data}, #{t_len} + 1);
         str;
       end)
@@ -131,7 +133,7 @@ passive class String
       data  = this.data
     in
       new String(embed (embed char* end)
-        char *str = encore_alloc(_ctx, #{t_len} + 1);
+        char *str = encore_alloc(encore_ctx(), #{t_len} + 1);
         for (int i = 0; i < #{t_len}; ++i)
           {
             str[i] = toupper(((char *)#{data})[i]);
@@ -147,7 +149,7 @@ passive class String
       data  = this.data
     in
       new String(embed (embed char* end)
-        char *str = encore_alloc(_ctx, #{t_len} + 1);
+        char *str = encore_alloc(encore_ctx(), #{t_len} + 1);
         for (int i = 0; i < #{t_len}; ++i)
           {
             str[i] = tolower(((char *)#{data})[i]);
@@ -178,7 +180,7 @@ passive class String
       then Just new String(embed (embed char* end)
           int siz = #{to} - #{from};
           siz = siz < #{t_len} ? siz : #{t_len};
-          char *str = encore_alloc(_ctx, siz + 1);
+          char *str = encore_alloc(encore_ctx(), siz + 1);
           strncpy(str, ((char *)#{data})+#{from}, siz);
           str[siz] = '\0';
           str;
@@ -264,6 +266,7 @@ passive class String
       char *from = _this->_enc__field_data;
       char *pattern  = #{s}->_enc__field_data;
       char *tmp = NULL;
+      _ctx = encore_ctx();
 
       if (#{to_len} > STACK_ALLOC_MAX) { tmp = encore_alloc(_ctx, #{to_len} + 1); } else { tmp = alloca(#{to_len}); }
 

--- a/src/tests/encore/basic/stringTrace.enc
+++ b/src/tests/encore/basic/stringTrace.enc
@@ -2,6 +2,7 @@ class Foo
   def foo() : String {
     let s =
       embed (embed char* end)
+        _ctx = encore_ctx();
         char *s = encore_alloc(_ctx, 1000);
         strcpy(s, "Hello");
         s;


### PR DESCRIPTION
Since the context can go stale when a thread is blocking, we need to
refresh it before it is used for allocation. This is done in the runtime
libraries but had been forgotten for the String library. As this is a 
non-deterministic error, it is difficult to test.
