### PR TITLE
fix #372: misleading build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Run: `brew update; brew install llvm`
 ##### Installing `premake4`
 
 Go to the [Premake4 Download page](http://premake.github.io/download.html),
-download and install `premake4`. 
+download and install `premake4`.
 
 Alternatively, run: `brew update; brew install premake`
 
@@ -128,6 +128,22 @@ distributions based on Ubuntu or Debian.
 	# update cabal packages
 	cabal update && cabal install cabal-install
 
+At this point, `ghc-7.10.2` has been installed in `/opt/ghc/`.
+
+**NOTE**: If you have another version of Haskell, Encore needs `ghc-7.10.2` to work:
+You can add `/opt/` as the first folder in the `$PATH`. If you want
+to hack on Encore without changing your global `$PATH`:
+
+```
+export PATH="/opt/ghc/:$PATH"
+```
+
+If you want to change this globally (you won't need to do this everytime
+you open a terminal), then:
+
+```
+echo export PATH="/opt/ghc/:$PATH" >> ~/.profile
+```
 
 ##### Version checking
 


### PR DESCRIPTION
there was missing information on how to install Encore when you already have a different version of `ghc`. this commit adds information on how to make it work with different versions. the proposed solution is to update the `$PATH` variable to start with `/opt/ghc`. the commit provides information on how to do this globally or locally.
