### PR TITLE
update documentation section in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,18 +215,13 @@ Running `encorec foo.enc` will typecheck the source and produce the executable
 
 Update the language specification whenever you change the Encore compiler.
 
-#### Dependencies
+#### Generate documentation
 
-In order to update the language specification, first you need to:
+Generate the documentation and check your changes by typing:
 
-  1. download the [Racket language](http://download.racket-lang.org/)
-  2. clone the project upscale (https://github.com/fxpl/upscale)
-  3. cd upscale/doc/encore
-  4. make
+  - `make doc`
 
-After following the instructions above, you should have a folder under
-`upscale/doc/encore` named `build` that contains the documentation in
-pdf and html.
+After this, you should have a folder under `encore/doc/encore` named `build` that contains the documentation in pdf and html.
 
 #### Update the language specification
 


### PR DESCRIPTION
the current `README.md` states that the Encore documentation is in the
upscale repo, which is wrong.

> ## Language Specification
> 
> Update the language specification whenever you change the Encore compiler.
> #### Dependencies
> 
> In order to update the language specification, first you need to:
> 1. download the [Racket language](http://download.racket-lang.org/)
> 2. clone the project upscale (https://github.com/fxpl/upscale)
> 3. cd upscale/doc/encore
> 4. make
> 
> After following the instructions above, you should have a folder under
> `upscale/doc/encore` named `build` that contains the documentation in
> pdf and html.
