### PR TITLE
Let pretty printing use OverloadedStrings

### DIFF
--- a/emacs/encore-mode.el
+++ b/emacs/encore-mode.el
@@ -10,17 +10,76 @@
 ;; init-file. There is a hook to enable encore-mode for all files
 ;; with extension .enc.
 
-(setq encore-keywords '("and" "async" "await" "by" "class" "chain" "def" "else"
-                        "eos" "for" "foreach" "get" "getNext" "if" "in" "join"
-                        "let" "liftf" "liftv" "match" "new" "not" "or" "passive"
-                        "print" "repeat" "require" "stream" "suspend" "then"
-                        "this" "trait" "unless" "val" "when" "while" "with"
-                        "yield" "typedef"))
+;; Please keep these lists sorted
+(setq encore-keywords
+      '(
+        "and"
+        "async"
+        "await"
+        "by"
+        "chain"
+        "class"
+        "def"
+        "else"
+        "eos"
+        "for"
+        "foreach"
+        "get"
+        "getNext"
+        "if"
+        "in"
+        "join"
+        "let"
+        "liftf"
+        "liftv"
+        "match"
+        "new"
+        "not"
+        "or"
+        "passive"
+        "print"
+        "repeat"
+        "require"
+        "stream"
+        "suspend"
+        "then"
+        "this"
+        "trait"
+        "typedef"
+        "unless"
+        "val"
+        "when"
+        "while"
+        "with"
+        "yield"
+        ))
 
-(setq encore-danger-words '("embed" "body" "end"))
-(setq encore-constants '("true" "false" "null"))
-(setq encore-primitives '("bool" "char" "int" "string" "void" ))
-(setq encore-operators '("||" ">>"))
+(setq encore-danger-words
+      '(
+        "body"
+        "embed"
+        "end"
+        ))
+(setq encore-constants
+      '(
+        "false"
+        "null"
+        "true"
+        ))
+
+(setq encore-primitives
+      '(
+        "bool"
+        "char"
+        "int"
+        "void"
+        ))
+
+(setq encore-operators
+      '(
+        "||"
+        ">>"
+        ))
 
 (setq encore-keywords-regexp (regexp-opt encore-keywords 'symbols))
 (setq encore-danger-regexp (regexp-opt encore-danger-words 'symbols))

--- a/src/back/CCode/PrettyCCode.hs
+++ b/src/back/CCode/PrettyCCode.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE GADTs,FlexibleContexts #-}
+{-# LANGUAGE GADTs,FlexibleContexts,OverloadedStrings #-}
 {-# OPTIONS_GHC -fwarn-incomplete-patterns #-}
 
 {-|
@@ -21,68 +21,72 @@ tshow :: Show t => t -> Doc
 tshow = text . show
 
 addSemi :: Doc -> Doc
-addSemi d = if show d == "" then d
-             else if isSuffixOf ";" $ show d then d else d <> text ";"
+addSemi d |  null (show d)
+          || isSuffixOf ";" (show d) = d
+          | otherwise = d <> ";"
 
-star :: Doc
-star = text "*"
+commaSep :: [Doc] -> Doc
+commaSep = hcat . intersperse ", "
 
 switchBody :: [(CCode Name, CCode Stat)] -> CCode Stat -> Doc
 switchBody ccodes defCase =
-  lbrace $+$ (nest 2 $ vcat (map switchClause ccodes) $+$
-      text "default:" $+$
-      (bracedBlock . vcat . map pp') [defCase]) $+$
-  rbrace
+  bracedBlock $ vcat (map switchClause ccodes) $+$
+                "default:" $+$ (bracedBlock . vcat . map pp') [defCase]
   where
     switchClause :: (CCode Name, CCode Stat) -> Doc
     switchClause (lhs,rhs) =
-      text "case" <+> pp' lhs <> text ":"
-               $+$ (bracedBlock . vcat . map pp') (rhs:[Embed "break;"])
+      "case" <+> pp' lhs <> ":"
+             $+$ (bracedBlock . vcat . map pp') (rhs:[Embed "break;"])
 
 pp' :: CCode a -> Doc
 pp' (Program cs) = pp' cs
 pp' Skip = empty
-pp' Null = text "NULL"
+pp' Null = "NULL"
 pp' (Includes ls) = vcat $ map (text . ("#include <"++) . (++">")) ls
-pp' (LocalInclude s) = text "#include" <+> doubleQuotes (text s)
-pp' (IfDefine str ccode) = text "#ifdef" <+> text str $+$ pp' ccode $+$ text "#endif /* ifdef" <+> text str <+> text "*/"
-pp' (IfNDefine str ccode) = text "#ifndef" <+> text str $+$ pp' ccode $+$ text "#endif /* ifndef" <+> text str <+> text "*/"
-pp' (HashDefine str) = text $ "#define " ++ str
-pp' (Statement other) =  addSemi $ pp' other
-pp' (Switch tst ccodes def) = text "switch" <+> parens (tshow tst)  $+$
-                              switchBody ccodes def
-pp' (StructDecl name vardecls) = text "struct " <> tshow name $+$
-                                 (addSemi . bracedBlock . vcat) (map pp' fields)
-    where fields = map (\ (ty, id) -> Embed $ show ty ++ " " ++ show id ++ ";") vardecls
-pp' (Struct name) = text "struct " <> tshow name
+pp' (LocalInclude s) = "#include" <+> doubleQuotes (text s)
+pp' (IfDefine str ccode) =
+  "#ifdef" <+> text str $+$ pp' ccode $+$
+  "#endif /* ifdef" <+> text str <+> "*/"
+pp' (IfNDefine str ccode) =
+  "#ifndef" <+> text str $+$ pp' ccode $+$
+  "#endif /* ifndef" <+> text str <+> text "*/"
+pp' (HashDefine str) = "#define" <+> text str
+pp' (Statement other) = addSemi $ pp' other
+pp' (Switch tst ccodes def) =
+  "switch" <+> parens (tshow tst)  $+$
+               switchBody ccodes def
+pp' (StructDecl name vardecls) =
+  "struct " <> tshow name $+$ (addSemi . bracedBlock . vcat) (map pp' fields)
+  where
+    fields =
+      map (\(ty, id) -> Embed $ show ty ++ " " ++ show id ++ ";") vardecls
+pp' (Struct name) = "struct " <> tshow name
 pp' (Record ccodes) = braces $ commaList ccodes
-pp' (Assign lhs rhs) = addSemi $ pp' lhs <+> text "=" <+> pp' rhs
-pp' (AssignTL lhs rhs) = addSemi $ pp' lhs <+> text "=" <+> pp' rhs
+pp' (Assign lhs rhs) = addSemi $ pp' lhs <+> "=" <+> pp' rhs
+pp' (AssignTL lhs rhs) = addSemi $ pp' lhs <+> "=" <+> pp' rhs
 pp' (Decl (ty, id)) = tshow ty <+> tshow id
 pp' (DeclTL (ty, id)) = addSemi $ tshow ty <+> tshow id
-pp' (FunTypeDef id ty argTys) = addSemi $ text "typedef" <+> tshow ty <+> parens (star <> tshow id) <>
-                                parens (commaList argTys)
-pp' (Concat ccodes) = vcat $ intersperse (text "\n") $ map pp' ccodes
+pp' (FunTypeDef id ty argTys) =
+  addSemi $ "typedef" <+> tshow ty <+> parens ("*" <> tshow id) <>
+            parens (commaList argTys)
+pp' (Concat ccodes) = vcat $ intersperse "\n" $ map pp' ccodes
 pp' (Seq ccodes) = vcat $ map (addSemi . pp') ccodes
---    where
---      pp'' :: UsableAs Stat s => CCode s -> Doc
---      pp'' (Seq ccodes) = vcat $ map pp'' ccodes
---      pp'' other = pp' other
-pp' (Enum ids) = text "enum" $+$ bracedBlock (vcat $ map (\id -> tshow id <> text ",") ids) <> text ";"
+pp' (Enum ids) =
+  "enum" $+$ bracedBlock (vcat $ map (\id -> tshow id <> ",") ids) <> ";"
 pp' (Braced ccode) = (bracedBlock . pp') ccode
 pp' (Parens ccode) = parens $ pp' ccode
 pp' (CUnary o e) = parens $  pp' o <+> pp' e
 pp' (BinOp o e1 e2) = parens $  pp' e1 <+> pp' o <+> pp' e2
-pp' (Dot ccode id) = pp' ccode <> text "." <> tshow id
-pp' (Arrow ccode id) = pp' ccode <> text "->" <> tshow id
-pp' (Deref ccode) = parens $ star <> pp' ccode
-pp' (Cast ty e) = parens $ (parens $ pp' ty) <+> pp' e
+pp' (Dot ccode id) = pp' ccode <> "." <> tshow id
+pp' (Arrow ccode id) = pp' ccode <> "->" <> tshow id
+pp' (Deref ccode) = parens $ "*" <> pp' ccode
+pp' (Cast ty e) = parens $ parens (pp' ty) <+> pp' e
 pp' (ArrAcc i l) = parens $  pp' l <> brackets (tshow i)
-pp' (Amp ccode) = parens $ text "&" <> (parens $ pp' ccode)
-pp' (Ptr ty) = pp' ty <> star
+pp' (Amp ccode) = parens $ "&" <> parens (pp' ccode)
+pp' (Ptr ty) = pp' ty <> "*"
 pp' (FunctionDecl retTy name args) =
   tshow retTy <+> tshow name <>
-  parens (commaList args) <> text ";"
+  parens (commaList args) <> ";"
 pp' (Function retTy name args body) =
   tshow retTy <+> tshow name <>
   parens (ppArgs args)  $+$
@@ -93,60 +97,59 @@ pp' (AsType c) = pp' c
 pp' (Nam st) = text st
 pp' (Var st) = text st
 pp' (Typ st) = text st
-pp' (Static ty) = text "static" <+> pp' ty
-pp' (Extern ty) = text "extern" <+> pp' ty
+pp' (Static ty) = "static" <+> pp' ty
+pp' (Extern ty) = "extern" <+> pp' ty
 pp' (Embed string) = text string
 pp' (EmbedC ccode) = pp' ccode
 pp' (Call name args) = tshow name <> parens (commaList args)
-pp' (Typedef ty name) = text "typedef" <+> pp' ty <+> tshow name <> text ";"
-pp' (Sizeof ty) = text "sizeof" <> parens (pp' ty)
-pp' (While cond body) = text "while" <+> parens (pp' cond) $+$
-                        bracedBlock (pp' body)
-pp' (StatAsExpr n s) = text "({" <> pp' s <+> pp' n <> text ";})"
-pp' (If c t e) = text "if" <+> parens  (pp' c) $+$
-                   bracedBlock (pp' t) $+$
-                 text "else" $+$
-                   bracedBlock (pp' e)
-pp' (Ternary c t e) = pp' c <> text "?" <+> pp' t <> text ":" <+> pp' e
-pp' (Return e) = text "return" <+> pp' e <> text ";"
-pp' (UnionInst name e) = text "{." <> tshow name <+> text "=" <+> pp' e <> text "}"
+pp' (Typedef ty name) = "typedef" <+> pp' ty <+> tshow name <> ";"
+pp' (Sizeof ty) = "sizeof" <> parens (pp' ty)
+pp' (While cond body) =
+  "while" <+> parens (pp' cond) $+$
+              bracedBlock (pp' body)
+pp' (StatAsExpr n s) = "({" <> pp' s <+> pp' n <> ";})"
+pp' (If c t e) =
+  "if" <+> parens  (pp' c) $+$
+    bracedBlock (pp' t) $+$
+  "else" $+$
+    bracedBlock (pp' e)
+pp' (Ternary c t e) = pp' c <> "?" <+> pp' t <> ":" <+> pp' e
+pp' (Return e) = "return" <+> pp' e <> ";"
+pp' (UnionInst name e) = "{." <> tshow name <+> "=" <+> pp' e <> "}"
 pp' (Int n) = tshow n
 pp' (String s) = tshow s
 pp' (Char c) = tshow c
 pp' (Double d) = tshow d
-pp' (Comm s) = text ("/* "++s++" */")
+pp' (Comm s) = text $ "/* " ++ s ++ " */"
 pp' (Annotated s ccode) = pp' ccode <+> pp' (Comm s)
 pp' (FunPtrDecl t name argTypes) =
   let
     args = parens (commaList argTypes)
-    id = text "(*" <> pp' name <> text ")"
+    id = "(*" <> pp' name <> ")"
   in
     pp' t <+> id <+> args
 pp' (CompoundLiteral t pairs) =
   let
-    struct = text "(" <> pp' t <> text ")"
-    pairs' = [text "." <> pp' l <> text "=" <> pp' r | (l,r) <- pairs]
-    body = hcat $ intersperse (text ", ") pairs'
-    braced = text "{" <> body <> text "}"
+    struct = "(" <> pp' t <> ")"
+    pairs' = ["." <> pp' l <> "=" <> pp' r | (l,r) <- pairs]
+    body = commaSep pairs'
+    braced = "{" <> body <> "}"
   in
-    text "&" <> struct <> braced
+    "&" <> struct <> braced
 pp' (DesignatedInitializer pairs) =
   let
-    pairs' = [text "." <> pp' l <> text "=" <> pp' r | (l,r) <- pairs]
-    body = hcat $ intersperse (text ", ") pairs'
+    pairs' = ["." <> pp' l <> "=" <> pp' r | (l,r) <- pairs]
+    body = commaSep pairs'
   in
-    text "{" <> body <> text "}"
+    "{" <> body <> "}"
 
 commaList :: [CCode a] -> Doc
-commaList l = hcat $ intersperse (text ", ") $ map pp' l
+commaList l = commaSep $ map pp' l
 
 ppArgs :: [CVarSpec] -> Doc
 ppArgs [] = empty
-ppArgs as = hcat $ intersperse (text ", ") $ map ppArg as
-ppArg = \(ty, id) -> tshow ty <+> tshow id
-
-block :: [CCode a] -> Doc
-block = vcat . map pp'
+ppArgs as = commaSep $ map ppArg as
+ppArg (ty, id) = tshow ty <+> tshow id
 
 bracedBlock :: Doc -> Doc
 bracedBlock doc = lbrace $+$

--- a/src/ir/AST/PrettyPrinter.hs
+++ b/src/ir/AST/PrettyPrinter.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fwarn-incomplete-patterns #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 {-|
 
@@ -19,75 +20,21 @@ module AST.PrettyPrinter (ppExpr
 
 -- Library dependencies
 import Text.PrettyPrint
-import Data.List(intercalate)
 
 -- Module dependencies
 import Identifiers
 import Types
 import AST.AST
 
-ppClass = text "class"
-ppSkip = text "()"
-ppBreathe = text "breathe"
-ppLet = text "let"
-ppIn = text "in"
-ppIf = text "if"
-ppThen = text "then"
-ppElse = text "else"
-ppUnless = text "unless"
-ppWhile = text "while"
-ppRepeat = text "repeat"
-ppFor = text "for"
-ppGet = text "get"
-ppYield = text "yield"
-ppEos = text "eos"
-ppAwait = text "await"
-ppSuspend = text "suspend"
-ppNull = text "null"
-ppTrue = text "true"
-ppFalse = text "false"
-ppNew = text "new"
-ppPeer = text "peer"
-ppPrint = text "print"
-ppExit = text "exit"
-ppEmbed = text "embed"
-ppEnd = text "end"
-ppForeach = text "foreach"
-ppFinish = text "finish"
-ppDot = text "."
-ppBang = text "!"
-ppColon = text ":"
-ppComma = text ","
-ppSemicolon = text ";"
-ppEquals = text "="
-ppSpace = text " "
-ppLambda = text "\\"
-ppArrow = text "->"
-ppSeq = text ">>"
-ppLiftf = text "liftf"
-ppLiftv = text "liftv"
-ppJoin = text "join"
-ppPartyExtract = text "extract"
-ppPartyEach = text "each"
-ppTask = text "async"
-ppPar = text "||"
-ppBar = text "|"
-ppJust = text "Just"
-ppNothing = text "Nothing"
-ppMatch = text "match"
-ppWith = text "with"
-ppTypeDef = text "typedef"
-ppMatchArrow = text "=>"
-
 indent = nest 2
 
-commaSep l = cat $ punctuate (ppComma <> ppSpace) l
+commaSep l = cat $ punctuate ", " l
 
 ppName :: Name -> Doc
 ppName (Name x) = text x
 
 ppQName :: QName -> Doc
-ppQName q = cat $ punctuate ppDot (map ppName q)
+ppQName q = cat $ punctuate "." (map ppName q)
 
 ppType :: Type -> Doc
 ppType = text . show
@@ -101,64 +48,63 @@ ppProgram Program{bundle, etl=EmbedTL{etlheader=header, etlbody=code},
     vcat (map ppTypedef typedefs) $+$
     vcat (map ppFunction functions) $+$
     vcat (map ppClassDecl classes) $+$
-    text "" -- new line at end of file
+    "" -- new line at end of file
 
 ppHeader header code =
   if null header && null code
   then empty
-  else text "embed" $+$ text header $+$ text "body" $+$ text code $+$ text "end\n"
+  else "embed" $+$ text header $+$ "body" $+$ text code $+$ "end\n"
 
 ppBundleDecl :: BundleDecl -> Doc
 ppBundleDecl NoBundle = empty
-ppBundleDecl Bundle{bname} = text "bundle" <+> ppQName bname
+ppBundleDecl Bundle{bname} = "bundle" <+> ppQName bname
 
 ppImportDecl :: ImportDecl -> Doc
-ppImportDecl Import {itarget} = text "import" <+> ppQName itarget
+ppImportDecl Import {itarget} = "import" <+> ppQName itarget
 ppImportDecl PulledImport {} = error "Cannot pretty-print a pulled import"
 
 ppTypedef :: Typedef -> Doc
 ppTypedef Typedef { typedefdef=t } =
-    text "typedef" <+>
+    "typedef" <+>
     ppType t <+>
-    text "=" <+>
-    ppType (typeSynonymRHS t) 
+    "=" <+>
+    ppType (typeSynonymRHS t)
 
 ppFunctionHeader :: FunctionHeader -> Doc
 ppFunctionHeader header =
     ppName (hname header) <>
     parens (commaSep (map ppParamDecl (hparams header))) <+>
-    text ":" <+> ppType (htype header)
+    ":" <+> ppType (htype header)
 
 ppFunctionHelper :: FunctionHeader -> Expr -> Doc
 ppFunctionHelper funheader funbody =
-    text "def" <+> ppFunctionHeader funheader $+$
+    "def" <+> ppFunctionHeader funheader $+$
         indent (ppExpr funbody)
 
 ppFunction :: Function -> Doc
 ppFunction Function {funheader, funbody} =
     ppFunctionHelper funheader funbody
 ppFunction MatchingFunction {matchfunheaders, matchfunbodies} =
-    foldr ($+$) (text "") (zipWith ppFunctionHelper matchfunheaders matchfunbodies)
+    foldr ($+$) "" (zipWith ppFunctionHelper matchfunheaders matchfunbodies)
 
 ppClassDecl :: ClassDecl -> Doc
 ppClassDecl Class {cname, cfields, cmethods} =
-    ppClass <+> ppType cname $+$
-        (indent $
-                vcat (map ppFieldDecl cfields) $$
+    "class" <+> ppType cname $+$
+        indent (vcat (map ppFieldDecl cfields) $$
                 vcat (map ppMethodDecl cmethods))
 
 ppFieldDecl :: FieldDecl -> Doc
 ppFieldDecl = text . show
 
 ppParamDecl :: ParamDecl -> Doc
-ppParamDecl (Param {pname, ptype}) =  ppName pname <+> text ":" <+> ppType ptype
+ppParamDecl (Param {pname, ptype}) =  ppName pname <+> ":" <+> ppType ptype
 
 ppMethodDecl :: MethodDecl -> Doc
 ppMethodDecl m =
     let header = mheader m
         body = mbody m
-        def | isStreamMethod m = text "stream"
-            | otherwise = text "def"
+        def | isStreamMethod m = "stream"
+            | otherwise = "def"
     in
       def <+> ppFunctionHeader header $+$
           indent (ppExpr body)
@@ -182,124 +128,128 @@ ppSugared e = case getSugared e of
                 Nothing -> ppExpr e
 
 ppExpr :: Expr -> Doc
-ppExpr Skip {} = ppSkip
-ppExpr Breathe {} = ppBreathe
+ppExpr Skip {} = "()"
+ppExpr Breathe {} = "breathe"
 ppExpr MethodCall {target, name, args} =
-    maybeParens target <> ppDot <> ppName name <>
+    maybeParens target <> "." <> ppName name <>
       parens (commaSep (map ppExpr args))
 ppExpr MessageSend {target, name, args} =
-    maybeParens target <> ppBang <> ppName name <>
+    maybeParens target <> "!" <> ppName name <>
       parens (commaSep (map ppExpr args))
-ppExpr Liftf {val} = ppLiftf <+> ppExpr val
-ppExpr Liftv {val} = ppLiftv <+> ppExpr val
-ppExpr PartyJoin {val} = ppJoin <+> ppExpr val
-ppExpr PartyExtract {val} = ppPartyExtract <+> ppExpr val
-ppExpr PartyEach {val} = ppPartyEach <+> ppExpr val
-ppExpr PartySeq {par, seqfunc} = ppExpr par <+> ppSeq <+> ppExpr seqfunc
-ppExpr PartyPar {parl, parr} = ppExpr parl <+> ppPar <+> ppExpr parr
+ppExpr Liftf {val} = "liftf" <+> ppExpr val
+ppExpr Liftv {val} = "liftv" <+> ppExpr val
+ppExpr PartyJoin {val} = "join" <+> ppExpr val
+ppExpr PartyExtract {val} = "extract" <+> ppExpr val
+ppExpr PartyEach {val} = "each" <+> ppExpr val
+ppExpr PartySeq {par, seqfunc} = ppExpr par <+> ">>" <+> ppExpr seqfunc
+ppExpr PartyPar {parl, parr} = ppExpr parl <+> "||" <+> ppExpr parr
 ppExpr FunctionCall {name, args} =
     ppName name <> parens (commaSep (map ppExpr args))
 ppExpr Closure {eparams, body} =
-    ppLambda <> parens (commaSep (map ppParamDecl eparams)) <+> ppArrow <+> ppExpr body
+    "\\" <> parens (commaSep (map ppParamDecl eparams)) <+> "->" <+> ppExpr body
 ppExpr Async {body} =
-    ppTask <> parens (ppExpr body)
-ppExpr (MaybeValue _ (JustData a)) = ppJust <+> ppExpr a
-ppExpr (MaybeValue _ NothingData) = ppNothing
+    "async" <> parens (ppExpr body)
+ppExpr (MaybeValue _ (JustData a)) = "Just" <+> ppExpr a
+ppExpr (MaybeValue _ NothingData) = "Nothing"
 ppExpr Tuple {args} = parens (commaSep (map ppExpr args))
 ppExpr Let {decls, body} =
-    ppLet <+> vcat (map (\(Name x, e) -> text x <+> equals <+> ppExpr e) decls) $+$ ppIn $+$
-      indent (ppExpr body)
+  "let" <+> vcat (map (\(Name x, e) -> text x <+> "=" <+> ppExpr e) decls) $+$
+  "in" $+$ indent (ppExpr body)
 ppExpr MiniLet {decl = (x, val)} =
-    ppLet <+> ppName x <+> equals <+> ppExpr val
+    "let" <+> ppName x <+> "=" <+> ppExpr val
 ppExpr Seq {eseq = [expr]} =
     ppExpr expr
 ppExpr Seq {eseq} =
-    braces $ vcat $ punctuate ppSemicolon (map ppExpr eseq)
+    braces $ vcat $ punctuate ";" (map ppExpr eseq)
 ppExpr IfThenElse {cond, thn, els} =
-    ppIf <+> ppExpr cond <+> ppThen $+$
+    "if" <+> ppExpr cond <+> "then" $+$
          indent (ppExpr thn) $+$
-    ppElse $+$
+    "else" $+$
          indent (ppExpr els)
 ppExpr IfThen {cond, thn} =
-    ppIf <+> ppExpr cond <+> ppThen $+$
+    "if" <+> ppExpr cond <+> "then" $+$
          indent (ppExpr thn)
 ppExpr Unless {cond, thn} =
-    ppUnless <+> ppExpr cond <+> ppThen $+$
+    "unless" <+> ppExpr cond <+> "then" $+$
          indent (ppExpr thn)
 ppExpr While {cond, body} =
-    ppWhile <+> ppExpr cond $+$
+    "while" <+> ppExpr cond $+$
          indent (ppExpr body)
 ppExpr Repeat {name, times, body} =
-    ppRepeat <+> ppName name <+> text "<-" <+> ppExpr times $+$
+    "repeat" <+> ppName name <+> "<-" <+> ppExpr times $+$
          indent (ppExpr body)
 ppExpr For {name, step = IntLiteral{intLit = 1}, src, body} =
-    ppFor <+> ppName name <+> ppIn <+> ppExpr src $+$
+    "for" <+> ppName name <+> "in" <+> ppExpr src $+$
          indent (ppExpr body)
 ppExpr For {name, step, src, body} =
-    ppFor <+> ppName name <+> ppIn <+> ppExpr src <+> text "by" <+> ppExpr step $+$
+    "for" <+> ppName name <+> "in" <+> ppExpr src <+> "by" <+> ppExpr step $+$
          indent (ppExpr body)
 ppExpr Match {arg, clauses} =
-    ppMatch <+> ppExpr arg <+> text "with" $+$
+    "match" <+> ppExpr arg <+> "with" $+$
          ppMatchClauses clauses
     where
       ppClause (MatchClause {mcpattern, mchandler, mcguard = BTrue{}}) =
-        indent (ppExpr mcpattern <+> text "=>" <+> ppExpr mchandler)
+        indent (ppExpr mcpattern <+> "=>" <+> ppExpr mchandler)
       ppClause (MatchClause {mcpattern, mchandler, mcguard}) =
-        indent (ppExpr mcpattern <+> text "when" <+> ppExpr mcguard <+>
-                       text "=>" <+> ppExpr mchandler)
-      ppMatchClauses = foldr (($+$) . ppClause) (text "")
+        indent (ppExpr mcpattern <+> "when" <+> ppExpr mcguard <+>
+                       "=>" <+> ppExpr mchandler)
+      ppMatchClauses = foldr (($+$) . ppClause) ""
 ppExpr FutureChain {future, chain} =
-    ppExpr future <+> text "~~>" <+> ppExpr chain
-ppExpr Get {val} = ppGet <+> ppExpr val
-ppExpr Yield {val} = ppYield <+> ppExpr val
-ppExpr Eos {} = ppEos <> parens empty
-ppExpr Await {val} = ppAwait <+> ppExpr val
-ppExpr IsEos {target} = ppExpr target <> ppDot <> ppEos <> parens empty
-ppExpr StreamNext {target} = ppExpr target <> ppDot <> text "next" <> parens empty
-ppExpr Suspend {} = ppSuspend
-ppExpr FieldAccess {target, name} = maybeParens target <> ppDot <> ppName name
+    ppExpr future <+> "~~>" <+> ppExpr chain
+ppExpr Get {val} = "get" <+> ppExpr val
+ppExpr Yield {val} = "yield" <+> ppExpr val
+ppExpr Eos {} = "eos" <> parens empty
+ppExpr Await {val} = "await" <+> ppExpr val
+ppExpr IsEos {target} = ppExpr target <> "." <> "eos" <> parens empty
+ppExpr StreamNext {target} = ppExpr target <> "." <> "next" <> parens empty
+ppExpr Suspend {} = "suspend"
+ppExpr FieldAccess {target, name} = maybeParens target <> "." <> ppName name
 ppExpr ArrayAccess {target, index} = ppExpr target <> brackets (ppExpr index)
-ppExpr ArraySize {target} = ppBar <> ppExpr target <> ppBar
+ppExpr ArraySize {target} = "|" <> ppExpr target <> "|"
 ppExpr ArrayNew {ty, size} = brackets (ppType ty) <> parens (ppExpr size)
 ppExpr ArrayLiteral {args} = brackets $ commaSep (map ppExpr args)
 ppExpr VarAccess {name} = ppName name
-ppExpr Assign {lhs, rhs} = ppExpr lhs <+> ppEquals <+> ppExpr rhs
-ppExpr Null {} = ppNull
-ppExpr BTrue {} = ppTrue
-ppExpr BFalse {} = ppFalse
-ppExpr NewWithInit {ty, args} = ppNew <+> ppType ty <> parens (commaSep (map ppExpr args))
-ppExpr New {ty} = ppNew <+> ppType ty
-ppExpr Peer {ty} = ppPeer <+> ppType ty
-ppExpr Print {args} = ppPrint <> parens (commaSep (map ppExpr args))
-ppExpr Exit {args} = ppExit <> parens (commaSep (map ppExpr args))
-ppExpr StringLiteral {stringLit} = text (show stringLit)
+ppExpr Assign {lhs, rhs} = ppExpr lhs <+> "=" <+> ppExpr rhs
+ppExpr Null {} = "null"
+ppExpr BTrue {} = "true"
+ppExpr BFalse {} = "false"
+ppExpr NewWithInit {ty, args} =
+  "new" <+> ppType ty <> parens (commaSep (map ppExpr args))
+ppExpr New {ty} = "new" <+> ppType ty
+ppExpr Peer {ty} = "peer" <+> ppType ty
+ppExpr Print {args} = "print" <> parens (commaSep (map ppExpr args))
+ppExpr Exit {args} = "exit" <> parens (commaSep (map ppExpr args))
+ppExpr StringLiteral {stringLit} = text $ show stringLit
 ppExpr CharLiteral {charLit} = text $ show charLit
 ppExpr IntLiteral {intLit} = int intLit
 ppExpr RealLiteral {realLit} = double realLit
-ppExpr RangeLiteral {start, stop, step} = text "[" <+> ppExpr start <+> text "," <+> ppExpr stop <+> text " by " <+> ppExpr step <+> text"]"
-ppExpr Embed {ty, code} = ppEmbed <+> ppType ty <+> text code <+> ppEnd
+ppExpr RangeLiteral {start, stop, step} =
+  "[" <+> ppExpr start <+> "," <+> ppExpr stop <+> "by" <+> ppExpr step <+> "]"
+ppExpr Embed {ty, code} = "embed" <+> ppType ty <+> text code <+> "end"
 ppExpr Unary {uop, operand} = ppUnary uop <+> ppExpr operand
-ppExpr Binop {binop, loper, roper} = ppExpr loper <+> ppBinop binop <+> ppExpr roper
-ppExpr TypedExpr {body, ty} = ppExpr body <+> ppColon <+> ppType ty
-ppExpr Foreach {item, arr, body} = ppForeach <+> ppName item <+> ppIn <+> ppExpr arr <>
-                                   braces (ppExpr body)
-ppExpr FinishAsync {body} = ppFinish <+> ppExpr body
+ppExpr Binop {binop, loper, roper} =
+  ppExpr loper <+> ppBinop binop <+> ppExpr roper
+ppExpr TypedExpr {body, ty} = ppExpr body <+> ":" <+> ppType ty
+ppExpr Foreach {item, arr, body} =
+  "foreach" <+> ppName item <+> "in" <+> ppExpr arr <>
+                braces (ppExpr body)
+ppExpr FinishAsync {body} = "finish" <+> ppExpr body
 
 ppUnary :: UnaryOp -> Doc
-ppUnary Identifiers.NOT = text "not"
-ppUnary Identifiers.NEG = text "-"
+ppUnary Identifiers.NOT = "not"
+ppUnary Identifiers.NEG = "-"
 
 ppBinop :: BinaryOp -> Doc
-ppBinop Identifiers.AND = text "and"
-ppBinop Identifiers.OR = text "or"
-ppBinop Identifiers.LT  = text "<"
-ppBinop Identifiers.GT  = text ">"
-ppBinop Identifiers.LTE  = text "<="
-ppBinop Identifiers.GTE  = text ">="
-ppBinop Identifiers.EQ  = text "=="
-ppBinop Identifiers.NEQ = text "!="
-ppBinop Identifiers.PLUS  = text "+"
-ppBinop Identifiers.MINUS = text "-"
-ppBinop Identifiers.TIMES  = text "*"
-ppBinop Identifiers.DIV = text "/"
-ppBinop Identifiers.MOD = text "%"
+ppBinop Identifiers.AND   = "and"
+ppBinop Identifiers.OR    = "or"
+ppBinop Identifiers.LT    = "<"
+ppBinop Identifiers.GT    = ">"
+ppBinop Identifiers.LTE   = "<="
+ppBinop Identifiers.GTE   = ">="
+ppBinop Identifiers.EQ    = "=="
+ppBinop Identifiers.NEQ   = "!="
+ppBinop Identifiers.PLUS  = "+"
+ppBinop Identifiers.MINUS = "-"
+ppBinop Identifiers.TIMES = "*"
+ppBinop Identifiers.DIV   = "/"
+ppBinop Identifiers.MOD   = "%"


### PR DESCRIPTION
This commit refactors the pretty printing of C and Encore ASTs, mainly
by using [OverloadedStrings](https://www.schoolofhaskell.com/school/to-infinity-and-beyond/pick-of-the-week/guide-to-ghc-extensions/basic-syntax-extensions#overloadedstrings). This GHC extension lets you use string literals
where another `String` like data-type is expected. The pretty printers 
work with the type `Doc`, meaning we had to write `text "*"` when we 
wanted a literal `"*"`. Now, the string literal is enough. Also cleaned up 
parts of the code and made the emacs mode more resilent to change.
