### PR TITLE
party comply with c11 standard

### DIFF
--- a/src/runtime/pony/premake4.lua
+++ b/src/runtime/pony/premake4.lua
@@ -185,9 +185,7 @@ project "closure"
 project "party"
   c_lib()
   links { "future", "array" }
-  buildoptions {
-      "-fms-extensions",
-  }
+
   files {
     "../party/party.*",
   }


### PR DESCRIPTION
This PR removes anonymous structs from the implementation and make it comply with the C11 standard. No more party warnings when compiling!
