### PR TITLE
Fix #206, allow primes in names

### DIFF
--- a/src/back/CodeGen/Context.hs
+++ b/src/back/CodeGen/Context.hs
@@ -26,6 +26,7 @@ import Control.Monad.State
 import qualified CodeGen.ClassTable as Tbl
 
 import qualified CCode.Main as C
+import CodeGen.CCodeNames
 
 type NextSym = Int
 
@@ -44,11 +45,12 @@ new subs ctable = Context subs 0 ctable
 
 genNamedSym :: String -> State Context String
 genNamedSym name = do
+  let (_, name') = fixPrimes name
   c <- get
   case c of
     Context s n t ->
         do put $ Context s (n+1) t
-           return $ "_" ++ name ++ "_" ++ show n
+           return $ "_" ++ name' ++ "_" ++ show n
 
 genSym :: State Context String
 genSym = genNamedSym "tmp"

--- a/src/back/CodeGen/Expr.hs
+++ b/src/back/CodeGen/Expr.hs
@@ -426,12 +426,11 @@ instance Translatable A.Expr (State Ctx.Context (CCode Lval, CCode Stat)) where
                       (Assign (Decl (translate (A.getType acc), Var tmp)) theAccess)])
 
   translate (A.Let {A.decls, A.body}) = do
-                     do
-                       tmpsTdecls <- mapM translateDecl decls
-                       let (tmps, tdecls) = unzip tmpsTdecls
-                       (nbody, tbody) <- translate body
-                       mapM_ unsubstituteVar (map fst decls)
-                       return (nbody, Seq $ (concat tdecls) ++ [tbody])
+    tmpsTdecls <- mapM translateDecl decls
+    let (tmps, tdecls) = unzip tmpsTdecls
+    (nbody, tbody) <- translate body
+    mapM_ (unsubstituteVar . fst) decls
+    return (nbody, Seq $ concat tdecls ++ [tbody])
 
   translate (A.NewWithInit {A.ty, A.args})
     | Ty.isActiveClassType ty = delegateUse callTheMethodOneway

--- a/src/tests/encore/basic/primeNames.enc
+++ b/src/tests/encore/basic/primeNames.enc
@@ -1,0 +1,21 @@
+typedef T' = Bar'
+
+trait Bar'
+
+passive class Foo'<t'> : T'
+  f' : t'
+  def m'(x' : t') : t'
+    x'
+
+class Baz'<t'>
+
+class Main
+  def main() : void {
+    let foo = new Foo'<int>;
+    let baz = new Baz'<Foo'<int>>;
+    let x = "This";
+    let x' = "is";
+    let x'' = "prime";
+    let x''' = "stuff!";
+    print("{} {} {} {}\n", x, x', x'', x''')
+  }

--- a/src/tests/encore/basic/primeNames.out
+++ b/src/tests/encore/basic/primeNames.out
@@ -1,0 +1,1 @@
+This is prime stuff!


### PR DESCRIPTION
This commit adds support for using primes in identifiers. It has been
tested for variables, type variables, methods, fields, classes, traits
and typedefs. The renaming scheme is somewhat intricate to prevent
non-clashing identifiers from clashing at the C-level. There is an added
test `primeNames.enc`.
