### PR TITLE
Cleanup: Removed some unused test code

### DIFF
--- a/src/tests/encore/concurrency/Makefile
+++ b/src/tests/encore/concurrency/Makefile
@@ -1,14 +1,10 @@
 ENCORE_SOURCES=$(shell ls *.enc)
 ENCORE_TARGETS=$(ENCORE_SOURCES:.enc=)
 
-test: embed_tl.o
+test:
 	@./test.sh $(ENCORE_SOURCES)
-
-embed_tl.o: embed_tl.c embed_tl.h
-	clang -c embed_tl.c
 
 clean:
 	rm -rf *.dSYM *_src $(ENCORE_TARGETS)
-	rm -f embed_tl.o
 
 .PHONY: test clean


### PR DESCRIPTION
Some test code related to embedding (`embed_tl.[ch]`) was copied from the `basic` test directory to the `concurrency` test directory, but it was not used. Removed as it did not belong there.
