### PR TITLE
Updated broken link to Upscale project web site.

### DIFF
--- a/doc/encore/README.md
+++ b/doc/encore/README.md
@@ -1,6 +1,6 @@
 # Encore Documentation
 
-To learn more about Encore, visit [upscale-project](www.upscale-project.eu)
+To learn more about Encore, visit [upscale-project](https://upscale.project.cwi.nl/)
 
 The documentation is written using [Scribble](http://docs.racket-lang.org/scribble/),
 which generates both html and pdf (with embedded math).


### PR DESCRIPTION
The current link in `doc/encore/README.md` is relative and doesn't work.
An updated and absolute address (`https://upscale.project.cwi.nl/`) has been added instead.
