### PR TITLE
Fix #204 — calling methods on null receiver does not crash

### DIFF
--- a/src/runtime/encore/encore.h
+++ b/src/runtime/encore/encore.h
@@ -16,6 +16,8 @@
 #include <pony.h>
 #include <atomics.h>
 
+#define check_reciever(this, op, recv, msg, file) if (!this) { fprintf(stderr, "Error: empty receiver in " recv op msg "(...) in " file "\n"); abort(); }
+
 typedef struct context {
   ucontext_t uctx;
   struct context *next;

--- a/src/tests/encore/basic/recvNullCall.enc
+++ b/src/tests/encore/basic/recvNullCall.enc
@@ -1,0 +1,9 @@
+class Main
+  def test() : void
+    print("If you can read this, then recvNullCall failed")
+  def main() : void
+    let
+      x = null:Main
+    in 
+      x.test() 
+

--- a/src/tests/encore/basic/recvNullCall.err
+++ b/src/tests/encore/basic/recvNullCall.err
@@ -1,0 +1,1 @@
+Error: empty receiver in x.test(...) in "recvNullCall.enc" (line 8, column 7)

--- a/src/tests/encore/basic/recvNullSend.enc
+++ b/src/tests/encore/basic/recvNullSend.enc
@@ -1,0 +1,9 @@
+class Main
+  def test() : void
+    print("If you can read this, then recvNullSend failed")
+  def main() : void
+    let
+      x = null:Main
+    in 
+      x ! test() 
+

--- a/src/tests/encore/basic/recvNullSend.err
+++ b/src/tests/encore/basic/recvNullSend.err
@@ -1,0 +1,1 @@
+Error: empty receiver in x ! test(...) in "recvNullSend.enc" (line 8, column 9)


### PR DESCRIPTION
This PR adds an additional branch before each method call or message send in Encore. Basically

```
x.m() 
```

is turned into (mock C code):

```
if (x) { x.m(); } else { fprintf(stderr, "error message"); abort() }
```

An error message looks like this

```
Error: empty receiver in x ! test(...) in "src/tests/encore/basic/recvNullSend.enc" (line 8, column 9)
```

using `!` or `.` appropriately. 

The reason to add the branch at the call-site rather than at the beginning of each method was because;
1. non-null types will be able to avoid this check, but this cannot be done inside the method
2. the C compiler will be able to elide redundant checks and be smart about optimising

Note that the tests are written with PR 481 in mind. Without this PR, there is no support for testing this PR. 
