### PR TITLE
Update cabal build constraints to support newer GHC and base libraries

### DIFF
--- a/mylittlepony.cabal
+++ b/mylittlepony.cabal
@@ -30,7 +30,7 @@ executable encorec
                   , CPP
                   , ScopedTypeVariables
   build-depends: MissingH
-               , base >=4.7 && <=4.8.1.0
+               , base >=4.7 && <4.9
                , containers >= 0.5.5.1
                , directory >=1.2 && <1.3
                , hashable
@@ -40,7 +40,7 @@ executable encorec
                , process >=1.2 && <1.3
                , template-haskell
                , text >=1.1
-               , ghc == 7.10.2
+               , ghc >= 7.10
                , unix >=2.7 && <2.8
                , unordered-containers
   hs-source-dirs:      src/back src/front src/ir src/opt src/parser src/types


### PR DESCRIPTION
I've been locally patching my build file for each PR I'm reviewing for weeks. This fixes the issue.
