### PR TITLE
fixes removal of breathe AST nodes

### DIFF
--- a/src/ir/AST/AST.hs
+++ b/src/ir/AST/AST.hs
@@ -84,7 +84,7 @@ data Typedef = Typedef {
    typedefmeta :: Meta Typedef,
    typedefdef  :: Type  -- will be a TypeSynonym, with left and right hand side of definition built in
 } deriving (Show)
- 
+
 instance HasMeta Typedef where
     getMeta = typedefmeta
 
@@ -365,7 +365,6 @@ data MaybeContainer = JustData { e :: Expr}
                     | NothingData deriving(Eq, Show)
 
 data Expr = Skip {emeta :: Meta Expr}
-          | Breathe {emeta :: Meta Expr}
           | TypedExpr {emeta :: Meta Expr,
                        body :: Expr,
                        ty   :: Type}

--- a/src/ir/AST/Util.hs
+++ b/src/ir/AST/Util.hs
@@ -27,7 +27,6 @@ import Identifiers
 -- | @getChildren e@ returns all children of @e@ that are Exprs themselves
 getChildren :: Expr -> [Expr]
 getChildren Skip{} = []
-getChildren Breathe{} = []
 getChildren TypedExpr {body} = [body]
 getChildren MethodCall {target, args} = target : args
 getChildren MessageSend {target, args} = target : args
@@ -98,7 +97,6 @@ getChildren Binop {loper, roper} = [loper, roper]
 -- that @putChildren (getChildren e) e == e@ and @getChildren (putChildren l e) == l@
 putChildren :: [Expr] -> Expr -> Expr
 putChildren [] e@Skip{} = e
-putChildren [] e@Breathe{} = e
 putChildren [body] e@(TypedExpr {}) = e{body = body}
 putChildren (target : args) e@(MethodCall {}) = e{target = target, args = args}
 putChildren (target : args) e@(MessageSend {}) = e{target = target, args = args}
@@ -168,7 +166,6 @@ putChildren [loper, roper] e@(Binop {}) = e{loper = loper, roper = roper}
 -- This very explicit error handling is there to make
 -- -fwarn-incomplete-patterns help us find missing patterns
 putChildren _ e@Skip{} = error "'putChildren l Skip' expects l to have 0 elements"
-putChildren _ e@Breathe{} = error "'putChildren l Breathe' expects l to have 0 elements"
 putChildren _ e@(TypedExpr {}) = error "'putChildren l TypedExpr' expects l to have 1 element"
 putChildren _ e@(MaybeValue {}) = error "'putChildren l MaybeValue' expects l to have 1 element"
 putChildren _ e@(Tuple {}) = error "'putChildren l Tuple' expects l to have 1 element"


### PR DESCRIPTION
the `breathe` keyword has been removed from the language. however, there
are still some places that still use this keyword. this is a
mistake and this commit removes those places -- basically the AST node for
`breathe` and some utility functions that do no need the AST node anymore.
this commit fixes #487
