### PR TITLE
Added make rule for omitting code generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ LIB_DIR=$(RELEASE_DIR)/lib
 
 all: encorec
 
+typecheck:
+	cabal build --ghc-option=-fno-code
+
 encorec: dirs pony cabal-config
 	export ENCORE_BUNDLES="$(CURDIR)/bundles/" && \
 	cabal build
@@ -105,4 +108,4 @@ clean:
 vagrant:
 	-@vagrant up
 
-.PHONY: all encorec fetch-hs-deps test dirs pony clean doc vagrant
+.PHONY: all encorec typecheck fetch-hs-deps test dirs pony clean doc vagrant


### PR DESCRIPTION
It turns out that the most expensive part of building encorec is the
code generation phases. The GHC option `-fno-code` stops after
typechecking, and on my machine the difference in runtime is 5 seconds
vs. ~1.45 minutes. This commit adds the rule `typecheck` to the root
makefile, which meant to be used when no executable needs to be
generated (i.e. for only checking code that you wrote).

Emacs users using haskell-mode might be interested in the following hack
to make the compilation command default to only typechecking, and also
try to start a new haskell session if no one is present:

```
(defun ec/haskell-typecheck ()
  (interactive)
  (progn
    (cond ((null haskell-session) (haskell-session-change)))
    (haskell-process-do-cabal "build --ghc-options=-fno-code")))

(add-hook 'haskell-mode-hook
   (function
    (lambda ()
      (local-set-key (kbd "C-c C-c") 'ec/haskell-typecheck))))
```
