### PR TITLE
Added support for line comments in IGNORED_FILES.grep

### DIFF
--- a/src/tests/IGNORED_FILES.grep
+++ b/src/tests/IGNORED_FILES.grep
@@ -1,3 +1,5 @@
+# This file support line comments.
+# Note that the # must appear first on the line
 encore/modules/ClosureImporter
 encore/modules/ClosureImp
 encore/modules/DeepLib

--- a/src/tests/bin/test
+++ b/src/tests/bin/test
@@ -136,7 +136,7 @@ function have_at_least_one_spec_file() {
 #
 ############################################################
 function test_enabled() {
-    ! echo $1 | grep -f IGNORED_FILES.grep > /dev/null
+    ! grep --invert-match "^#" < IGNORED_FILES.grep | grep $1 > /dev/null
 }
 
 ############################################################


### PR DESCRIPTION
This PR adds support for #-style comments in the IGNORED_FILES.grep file to explain things or temporary un-remove patterns. I've tested it locally on my machine. 
