### PR TITLE
Fix #514

### DIFF
--- a/src/types/Typechecker/Typechecker.hs
+++ b/src/types/Typechecker/Typechecker.hs
@@ -894,7 +894,7 @@ instance Checkable Expr where
       unless (isClassType ty' && not (isMainType ty')) $
              tcError $ ObjectCreationError ty'
       header <- findMethod ty' (Name "_init")
-      matchArgumentLength ty header args
+      matchArgumentLength ty' header args
       let expectedTypes = map ptype (hparams header)
       (eArgs, bindings) <- matchArguments args expectedTypes
       return $ setType ty' new{ty = ty', args = eArgs}


### PR DESCRIPTION
Fixed an error where printing the error message when giving the wrong number of arguments to a constructor would crash the compiler. See #514 for details. 

I am currently at ECOOP where the bandwidth is pretty bad, so I can only do PRs via GitHub. Sorry for the brevity.
