### PR TITLE
Fix #518

### DIFF
--- a/bundles/standard/String.enc
+++ b/bundles/standard/String.enc
@@ -54,7 +54,8 @@ def string_from_int(n : int) : String
   new String(embed
     (embed char* end)
     int n = #{n};
-    int len = n < 0? (int) ceil(log10(-n)) + 2:
+    int len = n == 0? 2:
+              n < 0? (int) ceil(log10(-n)) + 2:
                      (int) ceil(log10(n)) + 1;
     char *s = encore_alloc(encore_ctx(), len);
     sprintf(s, "%d", n);

--- a/src/tests/encore/stdlib/stringtest.enc
+++ b/src/tests/encore/stdlib/stringtest.enc
@@ -323,9 +323,11 @@ passive class Test
     let
       s1 = string_from_int(123456789)
       s2 = string_from_int(-42)
+      s3 = string_from_int(0)
     in {
       assertTrue(s1.equals("123456789"));
       assertTrue(s2.equals("-42"));
+      assertTrue(s3.equals("0"));
     }
 
   def test_to_int() : void


### PR DESCRIPTION
Calling `string_from_int(0)` would try to find the length of the string
by calculating `log10(0)` which is not defined. This has been fixed now.
