### PR TITLE
Features/union types

### DIFF
--- a/src/back/CodeGen/ClassTable.hs
+++ b/src/back/CodeGen/ClassTable.hs
@@ -64,7 +64,10 @@ lookupMethods cls ctable =
 
 lookupCalledType :: Type -> Name -> ClassTable -> Type
 lookupCalledType ty m ctable
-  | isRefType ty = ty
+  | isRefAtomType ty = ty
+  | isUnionType ty =
+      let tyAsCap = foldr1 disjunctiveType (unionMembers ty)
+      in lookupCalledType tyAsCap m ctable
   | isCapabilityType ty =
       let traits = typesFromCapability ty
           ttable = map (\t -> (t, snd $ lookupEntry t ctable)) traits

--- a/src/back/CodeGen/Trace.hs
+++ b/src/back/CodeGen/Trace.hs
@@ -22,7 +22,6 @@ traceVariable t var
   | Ty.isSharedClassType t  = traceActor var
   | Ty.isPassiveClassType t = traceObject var $ classTraceFnName t
   | Ty.isCapabilityType t   = traceCapability var
-  | Ty.isTraitType t        = traceCapability var
   | Ty.isFutureType t       = traceObject var futureTraceFn
   | Ty.isArrowType t        = traceObject var closureTraceFn
   | Ty.isArrayType t        = traceObject var arrayTraceFn

--- a/src/back/CodeGen/Type.hs
+++ b/src/back/CodeGen/Type.hs
@@ -26,8 +26,9 @@ translatePrimitive ty
 instance Translatable Ty.Type (CCode Ty) where
     translate ty
         | Ty.isPrimitive ty      = translatePrimitive ty
-        | Ty.isRefType ty        = Ptr . AsType $ classTypeName ty
+        | Ty.isRefAtomType ty    = Ptr . AsType $ classTypeName ty
         | Ty.isCapabilityType ty = capability
+        | Ty.isUnionType ty      = capability
         | Ty.isArrowType ty      = closure
         | Ty.isTypeVar ty        = encoreArgT
         | Ty.isFutureType ty     = future

--- a/src/tests/encore/union/ambiguous.enc
+++ b/src/tests/encore/union/ambiguous.enc
@@ -1,0 +1,22 @@
+trait Foo
+  def foo() : void
+    print "In Foo"
+
+trait Bar
+  def foo() : void
+    print "In Bar"
+
+trait Baz
+
+passive class C1 : Foo + Baz
+
+passive class C2 : Bar + Baz
+
+class Main
+  def main(): void {
+    let x = if true then
+              new C1
+            else
+              new C2;
+    x.foo();
+  }

--- a/src/tests/encore/union/ambiguous.fail
+++ b/src/tests/encore/union/ambiguous.fail
@@ -1,0 +1,1 @@
+Cannot disambiguate method 'foo'

--- a/src/tests/encore/union/composite.enc
+++ b/src/tests/encore/union/composite.enc
@@ -1,0 +1,24 @@
+def global(x : Foo) : void
+  print "In global"
+
+trait Foo
+  def foo() : void
+    print "In Foo"
+
+trait Bar
+
+trait Baz
+
+passive class C1 : Foo + Baz
+
+passive class C2 : Foo + Bar
+
+class Main
+  def main(): void {
+    let x = if true then
+              Just [new C1]
+            else
+              Just [new C2];
+    match x with
+      Just y => {(y[0]).foo(); global(y[0])}
+  }

--- a/src/tests/encore/union/composite.out
+++ b/src/tests/encore/union/composite.out
@@ -1,0 +1,2 @@
+In Foo
+In global

--- a/src/tests/encore/union/inference.enc
+++ b/src/tests/encore/union/inference.enc
@@ -1,0 +1,31 @@
+def global(x : Foo) : void
+  print "In global"
+
+trait Foo
+  def foo() : void
+    print "In Foo"
+
+trait Bar
+
+trait Baz
+
+passive class C1 : Foo + Bar
+passive class C2 : Foo + Baz
+passive class C3 : Baz + Foo
+
+class Main
+  def main(): void{
+    let x = match 1 with
+              0 => new C1()
+              1 => new C2()
+              2 => new C3()
+              3 => null;
+    let y = match 1 with
+              0 => Just new C1()
+              1 => Just new C2()
+              2 => Just new C3()
+              3 => Nothing;
+    match y with
+      Just z => {x.foo(); global(z)}
+      Nothing => ()
+  }

--- a/src/tests/encore/union/inference.out
+++ b/src/tests/encore/union/inference.out
@@ -1,0 +1,2 @@
+In Foo
+In global

--- a/src/tests/encore/union/lub.enc
+++ b/src/tests/encore/union/lub.enc
@@ -1,0 +1,23 @@
+def global(x : Foo) : void
+  print "In global"
+
+trait Foo
+  def foo() : void
+    print "In Foo"
+
+trait Bar
+
+trait Baz
+
+passive class C1 : Foo + Bar + Baz
+passive class C2 : Foo + Baz
+passive class C3 : Foo
+
+class Main
+  def main(): void{
+    let x = match 1 with
+              0 => new C1()
+              1 => new C2()
+              2 => new C3();
+    x : int
+  }

--- a/src/tests/encore/union/lub.fail
+++ b/src/tests/encore/union/lub.fail
@@ -1,0 +1,1 @@
+Type 'Foo' does not match

--- a/src/tests/encore/union/match.enc
+++ b/src/tests/encore/union/match.enc
@@ -1,0 +1,24 @@
+def global(x : Foo) : void
+  print "In global"
+
+trait Foo
+  def foo() : void
+    print "In Foo"
+
+trait Bar
+
+trait Baz
+
+passive class C1 : Foo + Bar
+passive class C2 : Foo + Baz
+passive class C3 : Baz + Foo
+
+class Main
+  def main(): void{
+    let x = match 1 with
+              0 => new C1()
+              1 => new C2()
+              2 => new C3();
+    x.foo();
+    global(x);
+  }

--- a/src/tests/encore/union/match.out
+++ b/src/tests/encore/union/match.out
@@ -1,0 +1,2 @@
+In Foo
+In global

--- a/src/tests/encore/union/nested.enc
+++ b/src/tests/encore/union/nested.enc
@@ -1,0 +1,31 @@
+def global(x : Foo) : void
+  print "In global"
+
+trait Foo
+  def foo() : void
+    print "In Foo"
+
+trait Bar
+
+trait Baz
+
+trait Frob
+
+passive class C1 : Foo + Baz
+
+passive class C2 : Foo + Bar
+
+passive class C3 : Foo + Frob
+
+class Main
+  def main(): void {
+    let x = match 42 with
+              0 => new C1
+              1 => if false then
+                     new C2
+                   else
+                     new C3
+              _ => new C3;
+    x.foo();
+    global(x);
+  }

--- a/src/tests/encore/union/nested.out
+++ b/src/tests/encore/union/nested.out
@@ -1,0 +1,2 @@
+In Foo
+In global

--- a/src/tests/encore/union/nooverlap.enc
+++ b/src/tests/encore/union/nooverlap.enc
@@ -1,0 +1,15 @@
+trait Foo
+trait Bar
+trait Baz
+
+passive class C1 : Foo + Bar
+passive class C2 : Foo + Baz
+passive class C3 : Baz + Bar
+
+class Main
+  def main(): void {
+    match 1 with
+      0 => new C1
+      1 => new C2
+      _ => new C3
+  }

--- a/src/tests/encore/union/nooverlap.fail
+++ b/src/tests/encore/union/nooverlap.fail
@@ -1,0 +1,1 @@
+Type 'Baz + Bar' is not compatible with

--- a/src/tests/encore/union/pattern.enc
+++ b/src/tests/encore/union/pattern.enc
@@ -1,0 +1,26 @@
+def global(x : Foo) : void
+  print "In global"
+
+trait Foo
+  def foo() : void
+    print "In Foo"
+  def id() : Maybe Foo
+    Just this
+
+trait Bar
+
+trait Baz
+
+passive class C1 : Foo + Bar
+passive class C2 : Foo + Baz
+passive class C3 : Baz + Foo
+
+class Main
+  def main(): void{
+    let x = match 1 with
+              0 => new C1()
+              1 => new C2()
+              2 => new C3();
+    match x with
+      id(y) => {y.foo(); global(x)}
+  }

--- a/src/tests/encore/union/pattern.out
+++ b/src/tests/encore/union/pattern.out
@@ -1,0 +1,2 @@
+In Foo
+In global

--- a/src/tests/encore/union/simple.enc
+++ b/src/tests/encore/union/simple.enc
@@ -1,0 +1,24 @@
+def global(x : Foo) : void
+  print "In global"
+
+trait Foo
+  def foo() : void
+    print "In Foo"
+
+trait Bar
+
+trait Baz
+
+passive class C1 : Foo + Baz
+
+passive class C2 : Foo + Bar
+
+class Main
+  def main(): void {
+    let x = if true then
+              new C1
+            else
+              new C2;
+    x.foo();
+    global(x);
+  }

--- a/src/tests/encore/union/simple.out
+++ b/src/tests/encore/union/simple.out
@@ -1,0 +1,2 @@
+In Foo
+In global

--- a/src/types/Typechecker/Environment.hs
+++ b/src/types/Typechecker/Environment.hs
@@ -14,7 +14,6 @@ module Typechecker.Environment(Environment,
                                refTypeLookup,
                                refTypeLookupUnsafe,
                                methodAndCalledTypeLookup,
-                               methodLookup,
                                fieldLookup,
                                capabilityLookup,
                                varLookup,
@@ -129,7 +128,7 @@ currentMethod = currentMethodFromBacktrace . bt
 
 formalBindings :: Type -> Type -> [(Type, Type)]
 formalBindings formal actual
-    | isRefType formal && isRefType actual =
+    | isRefAtomType formal && isRefAtomType actual =
         let formals = getTypeParameters formal
             actuals = getTypeParameters actual
         in
@@ -184,6 +183,10 @@ methodAndCalledTypeLookup ty m env
             results = map (\t -> (traitMethodLookup t m env, t)) traits
         (ret, ty') <- find (isJust . fst) results
         return (fromJust ret, ty')
+    | isUnionType ty = do
+        let members = unionMembers ty
+        mapM_ (\t -> methodLookup t m env) members
+        methodAndCalledTypeLookup (head members) m env
     | otherwise = do
         ret <- methodLookup ty m env
         return (ret, ty)
@@ -216,7 +219,7 @@ traitLookup t env =
 
 classLookup :: Type -> Environment -> Maybe ClassDecl
 classLookup cls env
-    | isRefType cls = Map.lookup (getId cls) $ classTable env
+    | isRefAtomType cls = Map.lookup (getId cls) $ classTable env
     | isTypeSynonym cls = classLookup (unfoldTypeSynonyms cls) env -- TODO: remove!!
     | otherwise = error $
       "Tried to lookup the class of '" ++ show cls

--- a/src/types/Typechecker/TypeError.hs
+++ b/src/types/Typechecker/TypeError.hs
@@ -117,6 +117,7 @@ refTypeName ty
     | isClassType ty = "class '" ++ getId ty ++ "'"
     | isTraitType ty = "trait '" ++ getId ty ++ "'"
     | isCapabilityType ty = "capability '" ++ show ty ++ "'"
+    | isUnionType ty = "union '" ++ show ty ++ "'"
     | otherwise = error $ "Util.hs: No refTypeName for " ++
                           Types.showWithKind ty
 
@@ -201,6 +202,8 @@ data Error =
   | TypeWithCapabilityMismatchError Type Type Type
   | TypeVariableAmbiguityError Type Type Type
   | FreeTypeVariableError Type
+  | UnionMethodAmbiguityError Type Name
+  | MalformedUnionTypeError Type Type
   | SimpleError String
 
 arguments 1 = "argument"
@@ -378,6 +381,12 @@ instance Show Error where
                (show expected) (show ty1) (show ty2)
     show (FreeTypeVariableError ty) =
         printf "Type variable '%s' is unbound" (show ty)
+    show (UnionMethodAmbiguityError ty name) =
+        printf "Cannot disambiguate method '%s' in %s"
+               (show name) (Types.showWithKind ty)
+    show (MalformedUnionTypeError ty union) =
+        printf "Type '%s' is not compatible with %s"
+               (show ty) (Types.showWithKind union)
     show (SimpleError msg) = msg
 
 

--- a/src/types/Typechecker/Typechecker.hs
+++ b/src/types/Typechecker/Typechecker.hs
@@ -409,7 +409,7 @@ instance Checkable Expr where
     doTypecheck mcall@(MethodCall {target, name, args}) = do
       eTarget <- typecheck target
       let targetType = AST.getType eTarget
-      unless (isRefType targetType || isCapabilityType targetType) $
+      unless (isRefType targetType) $
         tcError $ NonCallableTargetError targetType
       when (isMainMethod targetType name) $
            tcError MainMethodCallError
@@ -570,16 +570,18 @@ instance Checkable Expr where
           matchBranches ty1 ty2
               | isNullType ty1 && isNullType ty2 =
                   tcError IfInferenceError
-              | isNullType ty1 &&
-                (isRefType ty2 || isCapabilityType ty2) = return ty2
-              | isNullType ty2 &&
-                (isRefType ty1 || isCapabilityType ty1) = return ty1
-              | any isBottomType (typeComponents ty1) = ty1 `coercedInto` ty2
-              | any isBottomType (typeComponents ty2) = ty2 `coercedInto` ty1
-              | otherwise =
-                  if ty2 == ty1
-                  then return ty1
-                  else tcError $ IfBranchMismatchError ty1 ty2
+              | otherwise = do
+                  result <- unifyTypes [ty1, ty2]
+                  case result of
+                    Just ty -> return ty
+                    Nothing -> do
+                      ty1Sub <- ty1 `subtypeOf` ty2
+                      ty2Sub <- ty2 `subtypeOf` ty1
+                      if ty1Sub
+                      then return ty2
+                      else if ty2Sub
+                           then return ty1
+                           else tcError $ IfBranchMismatchError ty1 ty2
 
     --  E |- arg : t'
     --  clauses = (pattern1, guard1, expr1),..., (patternN, guardN, exprN)
@@ -599,19 +601,29 @@ instance Checkable Expr where
           tcError ActiveMatchError
         eClauses <- mapM (checkClause argType) clauses
         resultType <- checkAllHandlersSameType eClauses
-        return $ setType resultType match {arg = eArg, clauses = eClauses}
+        let updateClauseType m@MatchClause{mchandler} =
+                m{mchandler = setType resultType mchandler}
+            eClauses' = map updateClauseType eClauses
+        return $ setType resultType match {arg = eArg, clauses = eClauses'}
       where
-        checkAllHandlersSameType clauses =
-          case find (hasKnownType . mchandler) clauses of
-            Just clause -> do
-              let ty = AST.getType $ mchandler clause
-                  types = map (AST.getType . mchandler) clauses
-              mapM_ (`assertSubtypeOf` ty) types
-              return ty
+        checkAllHandlersSameType clauses = do
+          let types = map (AST.getType . mchandler) clauses
+          result <- unifyTypes types
+          case result of
+            Just ty -> return ty
             Nothing ->
-              tcError MatchInferenceError
+              case find (hasKnownType . mchandler) clauses of
+                Just e -> do
+                  let ty = AST.getType $ mchandler e
+                  mapM_ (`assertSubtypeOf` ty) types
+                  return ty
+                Nothing ->
+                  tcError MatchInferenceError
 
-        hasKnownType = all (not . isBottomType) . typeComponents . AST.getType
+        hasKnownType e =
+            let ty = AST.getType e
+            in all (not . isBottomType) (typeComponents ty) &&
+               not (isNullType ty)
 
         getPatternVars pt pattern =
             local (pushBT pattern) $
@@ -629,7 +641,7 @@ instance Checkable Expr where
             | otherwise = tcError $ PatternTypeMismatchError mcp pt
 
         doGetPatternVars pt fcall@(FunctionCall {name, args = [arg]}) = do
-          unless (isRefType pt || isCapabilityType pt) $
+          unless (isRefType pt) $
             tcError $ NonCallableTargetError pt
           header <- findMethod pt name
           let hType = htype header
@@ -690,8 +702,7 @@ instance Checkable Expr where
         doCheckPattern pattern@(TypedExpr{body, ty}) argty = do
           eBody <- checkPattern body argty
           ty' <- resolveType ty
-          unless (ty' == argty) $
-            tcError $ TypeMismatchError ty' argty
+          argty `assertSubtypeOf` ty'
           return $ setType ty' eBody
 
         doCheckPattern pattern argty
@@ -1128,7 +1139,7 @@ instance Checkable Expr where
 -- ---------------------
 --  null : ty
 coerceNull null ty
-    | isRefType ty || isCapabilityType ty = return $ setType ty null
+    | isRefType ty = return $ setType ty null
     | isNullType ty = tcError NullTypeInferenceError
     | otherwise =
         tcError $ CannotBeNullError ty
@@ -1161,7 +1172,7 @@ coercedInto actual expected
   where
     canBeNull ty =
       isRefType ty || isFutureType ty || isArrayType ty ||
-      isStreamType ty || isCapabilityType ty || isArrowType ty || isParType ty
+      isStreamType ty || isArrowType ty || isParType ty
 
 --  E |- arg1 : t
 --  matchTypes(B, t1, t) = B1

--- a/src/types/Typechecker/Util.hs
+++ b/src/types/Typechecker/Util.hs
@@ -19,6 +19,7 @@ module Typechecker.Util(TypecheckM
                        ,findMethodWithCalledType
                        ,findCapability
                        ,propagateResultType
+                       ,unifyTypes
                        ) where
 
 import Identifiers
@@ -49,6 +50,14 @@ whenM cond action = cond >>= (`when` action)
 
 unlessM :: (Monad m) => m Bool -> m () -> m ()
 unlessM cond action = cond >>= (`unless` action)
+
+findM :: (Monad m) => (a -> m Bool) -> [a] -> m (Maybe a)
+findM _ [] = return Nothing
+findM p (x:xs) = do
+  b <- p x
+  if b
+  then return $ Just x
+  else findM p xs
 
 -- | The monad in which all typechecking is performed. A function
 -- of return type @TypecheckM Bar@ may read from an 'Environment'
@@ -94,8 +103,8 @@ resolveSingleType ty
       unless (ty `elem` params) $
              tcError $ FreeTypeVariableError ty
       return ty
-  | isRefType ty = do
-      res <- resolveRefType ty
+  | isRefAtomType ty = do
+      res <- resolveRefAtomType ty
       if isTypeSynonym res
       then resolveType res -- Force unfolding of type synonyms
       else return res
@@ -109,10 +118,13 @@ resolveSingleType ty
       resolveType unfolded
   | otherwise = return ty
   where
-    resolveCapa t =
-        mapM_ resolveSingleTrait (typesFromCapability t) >> return t
+    resolveCapa t = do
+        let traits = typesFromCapability t
+        mapM_ resolveSingleTrait traits
+        assertDistinctThing "occurrence" "trait" traits
+        return t
     resolveSingleTrait t
-          | isRefType t = do
+          | isRefAtomType t = do
               result <- asks $ traitLookup t
               when (isNothing result) $
                  tcError $ UnknownTraitError t
@@ -123,21 +135,21 @@ resolveTypeAndCheckForLoops ty =
   evalStateT (typeMapM resolveAndCheck ty) []
   where
     resolveAndCheck ty
-      | isRefType ty = do
+      | isRefAtomType ty = do
           seen <- get
           let tyid = getId ty
           when (tyid `elem` seen) $
             lift . tcError $ RecursiveTypesynonymError ty
-          res <- lift $ resolveRefType ty
+          res <- lift $ resolveRefAtomType ty
           when (isTypeSynonym res) $ put (tyid : seen)
           if isTypeSynonym res
           then typeMapM resolveAndCheck res
           else return res
       | otherwise = lift $ resolveType ty
 
-resolveRefType :: Type -> TypecheckM Type
-resolveRefType ty
-  | isRefType ty = do
+resolveRefAtomType :: Type -> TypecheckM Type
+resolveRefAtomType ty
+  | isRefAtomType ty = do
       result <- asks $ refTypeLookup ty
       case result of
         Just formal -> do
@@ -165,9 +177,6 @@ subtypeOf ty1 ty2
     | isNullType ty1 = return (isNullType ty2 || isRefType ty2)
     | isClassType ty1 && isClassType ty2 =
         ty1 `refSubtypeOf` ty2
-    | isClassType ty1 && isTraitType ty2 = do
-        traits <- getImplementedTraits ty1
-        anyM (`subtypeOf` ty2) traits
     | isClassType ty1 && isCapabilityType ty2 = do
         capability <- findCapability ty1
         capability `capabilitySubtypeOf` ty2
@@ -186,6 +195,16 @@ subtypeOf ty1 ty2
         anyM (`subtypeOf` ty2) traits
     | isCapabilityType ty1 && isCapabilityType ty2 =
         ty1 `capabilitySubtypeOf` ty2
+    | isUnionType ty1 && isUnionType ty2 = do
+        let members1 = unionMembers ty1
+            members2 = unionMembers ty2
+        allM (\ty -> anyM (ty `subtypeOf`) members2) members1
+    | isUnionType ty1 = do
+        let members1 = unionMembers ty1
+        allM (`subtypeOf` ty2) members1
+    | isUnionType ty2 = do
+        let members2 = unionMembers ty2
+        anyM (ty1 `subtypeOf`) members2
     | isBottomType ty1 && (not . isBottomType $ ty2) = return True
     | isNumeric ty1 && isNumeric ty2 =
         return $ ty1 `numericSubtypeOf` ty2
@@ -209,6 +228,12 @@ subtypeOf ty1 ty2
           | isIntType ty1 && isRealType ty2 = True
           | otherwise = ty1 == ty2
 
+equivalentTo :: Type -> Type -> TypecheckM Bool
+equivalentTo ty1 ty2 = do
+  b1 <- ty1 `subtypeOf` ty2
+  b2 <- ty2 `subtypeOf` ty1
+  return $ b1 && b2
+
 -- | Convenience function for asserting distinctness of a list of
 -- things. @assertDistinct "declaration" "field" [f : Foo, f :
 -- Bar]@ will throw an error with the message "Duplicate
@@ -221,7 +246,7 @@ assertDistinctThing something kind l =
     duplicate = head duplicates
   in
     unless (null duplicates) $
-      tcError $ DuplicateThingError something (kind ++ show duplicate)
+      tcError $ DuplicateThingError something (kind ++ " " ++ show duplicate)
 
 -- | Convenience function for asserting distinctness of a list of
 -- things that @HasMeta@ (and thus knows how to print its own
@@ -249,11 +274,19 @@ findMethod :: Type -> Name -> TypecheckM FunctionHeader
 findMethod ty = liftM fst . findMethodWithCalledType ty
 
 findMethodWithCalledType :: Type -> Name -> TypecheckM (FunctionHeader, Type)
-findMethodWithCalledType ty name = do
-  result <- asks $ methodAndCalledTypeLookup ty name
-  when (isNothing result) $
-    tcError $ MethodNotFoundError name ty
-  return $ fromJust result
+findMethodWithCalledType ty name
+    | isUnionType ty = do
+        let members = unionMembers ty
+        results <- mapM (`findMethodWithCalledType` name) members
+        let result@(_, calledType) = head results
+        unless (all (==calledType) (map snd results)) $
+               tcError $ UnionMethodAmbiguityError ty name
+        return result
+    | otherwise = do
+        result <- asks $ methodAndCalledTypeLookup ty name
+        when (isNothing result) $
+          tcError $ MethodNotFoundError name ty
+        return $ fromJust result
 
 findCapability :: Type -> TypecheckM Type
 findCapability ty = do
@@ -294,3 +327,83 @@ propagateResultType ty e
 
       propagateMatchClause mc@MatchClause{mchandler} =
           mc{mchandler = propagateResultType ty mchandler}
+
+typeIsUnifiable ty
+    | isPassiveClassType ty = do
+        capability <- findCapability ty
+        return $ not (isIncapability capability)
+    | isCapabilityType ty = return $ not (isIncapability ty)
+    | otherwise =
+        return $
+        isUnionType ty ||
+        isNullType ty ||
+        isBottomType ty
+
+isUnifiableWith ty types
+    | isArrowType ty = return False
+    | hasResultType ty &&
+      all (hasSameKind ty) types =
+          isUnifiableWith (getResultType ty) (map getResultType types)
+    | isPassiveClassType ty = do
+      capability <- findCapability ty
+      if isIncapability capability
+      then return $ all (==ty) types
+      else allM typeIsUnifiable types
+    | otherwise = do
+        tyUniable <- typeIsUnifiable ty
+        tysUniable <- allM typeIsUnifiable types
+        return $ tyUniable && tysUniable &&
+                 not (isNullType ty) && not (isBottomType ty)
+
+unifyTypes :: [Type] -> TypecheckM (Maybe Type)
+unifyTypes tys = do
+  result <- findM (`isUnifiableWith` tys) tys
+  case result of
+    Just ty -> do
+      union <- doUnifyTypes ty tys
+      liftM Just $ lub union
+    Nothing ->
+      return Nothing
+  where
+    lub union = do
+      let members = unionMembers union
+      bounds <- filterM (\t -> allM (`subtypeOf` t) members) members
+      if null bounds
+      then return union
+      else return $ head bounds
+
+doUnifyTypes :: Type -> [Type] -> TypecheckM Type
+doUnifyTypes inter [] = return inter
+doUnifyTypes inter args@(ty:tys)
+    | hasResultType inter = do
+        let res = getResultType inter
+            args' = map getResultType args
+        res' <- doUnifyTypes res args'
+        return $ setResultType inter res'
+    | isNullType ty =
+        doUnifyTypes inter tys
+    | isBottomType ty =
+        doUnifyTypes inter tys
+    | isPassiveClassType ty =
+        if ty == inter
+        then doUnifyTypes inter tys
+        else do
+          cap <- findCapability ty
+          doUnifyTypes inter (cap:tys)
+    | isPassiveClassType inter = do
+        cap <- findCapability inter
+        doUnifyTypes cap (ty:tys)
+    | isCapabilityType ty = do
+        let members = unionMembers inter
+        isSubsumed <- anyM (ty `equivalentTo`) members
+        if isSubsumed
+        then doUnifyTypes inter tys
+        else do
+          unlessM (anyM (\t -> allM (`subtypeOf` t) members)
+                        (typesFromCapability ty)) $
+                 tcError $ MalformedUnionTypeError ty inter
+          doUnifyTypes (unionType inter ty) tys
+    | isUnionType ty =
+        doUnifyTypes inter (unionMembers ty ++ tys)
+    | otherwise =
+        error "Util.hs: Tried to form an union without a capability"

--- a/src/types/Types.hs
+++ b/src/types/Types.hs
@@ -18,6 +18,7 @@ module Types(
             ,refType
             ,traitTypeFromRefType
             ,classType
+            ,isRefAtomType
             ,isRefType
             ,isTraitType
             ,isActiveClassType
@@ -32,6 +33,9 @@ module Types(
             ,isCapabilityType
             ,incapability
             ,isIncapability
+            ,unionType
+            ,isUnionType
+            ,unionMembers
             ,typeVar
             ,isTypeVar
             ,replaceTypeVars
@@ -122,6 +126,7 @@ data Type = Unresolved{refInfo :: RefInfo}
           | CapabilityType{typeop :: TypeOp
                           ,ltype  :: Type
                           ,rtype  :: Type}
+          | UnionType{ltype :: Type, rtype :: Type}
           | EmptyCapability{}
           | TypeVar{ident :: String}
           | ArrowType{argTypes   :: [Type]
@@ -188,6 +193,7 @@ instance Show Type where
         in lhs ++ " " ++ show Product ++ " " ++ rhs
     show CapabilityType{typeop = Addition, ltype, rtype} =
         show ltype ++ " " ++ show Addition ++ " " ++ show rtype
+    show UnionType{ltype, rtype} = show ltype ++ " | " ++ show rtype
     show EmptyCapability = ""
     show TypeVar{ident} = ident
     show ArrowType{argTypes = [ty], resultType} =
@@ -217,12 +223,14 @@ instance Show Type where
     show BottomType = "Bottom"
 
 maybeParen :: Type -> String
-maybeParen arr@(ArrowType _ _) = "(" ++ show arr ++ ")"
-maybeParen fut@(FutureType _)  = "(" ++ show fut ++ ")"
-maybeParen par@(ParType _)     = "(" ++ show par ++ ")"
-maybeParen str@(StreamType _)  = "(" ++ show str ++ ")"
-maybeParen arr@(ArrayType _)   = "(" ++ show arr ++ ")"
-maybeParen opt@(MaybeType _)   = "(" ++ show opt ++ ")"
+maybeParen arr@(ArrowType{}) = "(" ++ show arr ++ ")"
+maybeParen fut@(FutureType{})  = "(" ++ show fut ++ ")"
+maybeParen par@(ParType{})     = "(" ++ show par ++ ")"
+maybeParen str@(StreamType{})  = "(" ++ show str ++ ")"
+maybeParen arr@(ArrayType{})   = "(" ++ show arr ++ ")"
+maybeParen opt@(MaybeType{})   = "(" ++ show opt ++ ")"
+maybeParen cap@(CapabilityType{}) = "(" ++ show cap ++ ")"
+maybeParen inter@(UnionType{}) = "(" ++ show inter ++ ")"
 maybeParen ty = show ty
 
 showWithKind :: Type -> String
@@ -239,6 +247,8 @@ showWithKind ty = kind ty ++ " " ++ show ty
     kind ClassType{activity = Active}  = "active class type"
     kind ClassType{activity = Passive} = "passive class type"
     kind CapabilityType{}              = "capability type"
+    kind EmptyCapability{}             = "the empty capability type"
+    kind UnionType{}                   = "union type"
     kind TypeVar{}                     = "polymorphic type"
     kind ArrowType{}                   = "function type"
     kind FutureType{}                  = "future type"
@@ -266,7 +276,6 @@ hasSameKind ty1 ty2
     areBoth isTupleType ||
     areBoth isTypeVar ||
     areBoth isRefType ||
-    areBoth isCapabilityType ||
     areBoth isArrowType = True
   | otherwise = False
   where
@@ -289,6 +298,8 @@ typeComponents ref@(ClassType{refInfo}) =
     ref : refInfoTypeComponents refInfo
 typeComponents cap@(CapabilityType{ltype, rtype}) =
     cap : typeComponents ltype ++ typeComponents rtype
+typeComponents ty@(UnionType{ltype, rtype}) =
+    ty : typeComponents ltype ++ typeComponents rtype
 typeComponents str@(StreamType ty) =
     str : typeComponents ty
 typeComponents arr@(ArrayType ty)  =
@@ -309,6 +320,9 @@ typeMap f ty@TraitType{refInfo} =
 typeMap f ty@ClassType{refInfo} =
     f ty{refInfo = refInfoTypeMap f refInfo}
 typeMap f ty@CapabilityType{ltype, rtype} =
+    f ty{ltype = typeMap f ltype
+        ,rtype = typeMap f rtype}
+typeMap f ty@UnionType{ltype, rtype} =
     f ty{ltype = typeMap f ltype
         ,rtype = typeMap f rtype}
 typeMap f ty@ArrowType{argTypes, resultType} =
@@ -345,6 +359,10 @@ typeMapM f ty@ClassType{refInfo} = do
   refInfo' <- refInfoTypeMapM f refInfo
   f ty{refInfo = refInfo'}
 typeMapM f ty@CapabilityType{ltype, rtype} = do
+  ltype' <- typeMapM f ltype
+  rtype' <- typeMapM f rtype
+  f ty{ltype = ltype', rtype = rtype'}
+typeMapM f ty@UnionType{ltype, rtype} = do
   ltype' <- typeMapM f ltype
   rtype' <- typeMapM f rtype
   f ty{ltype = ltype', rtype = rtype'}
@@ -431,10 +449,17 @@ traitTypeFromRefType Unresolved{refInfo} =
 traitTypeFromRefType ty =
     error $ "Types.hs: Can't make trait type from type: " ++ show ty
 
-isRefType Unresolved {} = True
-isRefType TraitType {} = True
-isRefType ClassType {} = True
-isRefType _ = False
+isRefAtomType Unresolved {} = True
+isRefAtomType TraitType {} = True
+isRefAtomType ClassType {} = True
+isRefAtomType _ = False
+
+isRefType ty
+    | isUnionType ty =
+        all isRefType (unionMembers ty)
+    | otherwise =
+        isRefAtomType ty ||
+        isCapabilityType ty
 
 isTraitType TraitType{} = True
 isTraitType _ = False
@@ -470,6 +495,14 @@ incapability = EmptyCapability
 
 isIncapability EmptyCapability = True
 isIncapability _ = False
+
+unionType = UnionType
+isUnionType UnionType{} = True
+isUnionType _ = False
+
+unionMembers UnionType{ltype, rtype} =
+    unionMembers ltype ++ unionMembers rtype
+unionMembers ty = [ty]
 
 arrowType = ArrowType
 isArrowType (ArrowType {}) = True


### PR DESCRIPTION
Backend support for union types

Fixes #348. This commit adds backend support for unio types.
Unio types take the form `T1 | T2` and should be interpreted as
a type that is **either** `T1` or `T2`. For now, this is only used as a
mechanism for handling the types of branching expressions (`if` and
`match`). For example, the `if` statement

```
if b then
  e1 : Foo
else
  e2 : Bar
```

will have the type `Foo | Bar`, meaning any operations performed on it
must be available in both `Foo` and `Bar` (in practice this is only true
if `Foo` and `Bar` has an overlap in their included capabilities). The
typechecker will try to get rid of union types when it can. For
example, if one of the branches has a type that is a subtype of all
other branches, the resulting type will be that type. If a class type is
encountered, its capability will be considered.

See `src/tests/encore/union` for tests and examples. As this is
not available to the programmer there is no documentation. When we find
a new home for the documentation (or if we decide to introduce
union types to the surface language) I can write something about
it.
