### PR TITLE
Fix #502: make boolean operator short-circuit

### DIFF
--- a/src/tests/encore/basic/short_circuit.enc
+++ b/src/tests/encore/basic/short_circuit.enc
@@ -1,0 +1,14 @@
+def foo() : bool {
+  print "In foo";
+  true
+}
+def bar() : bool {
+  print "In bar";
+  false
+}
+class Main
+  def main() : void
+    if foo() or bar() then
+      print "yes"
+    else
+      print "no"

--- a/src/tests/encore/basic/short_circuit.out
+++ b/src/tests/encore/basic/short_circuit.out
@@ -1,0 +1,2 @@
+In foo
+yes


### PR DESCRIPTION
It uses gcc extension: https://gcc.gnu.org/onlinedocs/gcc/Statement-Exprs.html for short-circuit, and the generated c code is fairly long (179 columns using the example from the issue).

IMO, The root cause is the usage of `Lval`.

```
instance Translatable A.Expr (State Ctx.Context (CCode Lval, CCode Stat)) where
```

while it could be:

```
instance Translatable A.Expr (State Ctx.Context CCode Expr) where
```
