### PR TITLE
Added flag for providing additional C flags.

### DIFF
--- a/doc/encore/lang/introduction/introduction.scrbl
+++ b/doc/encore/lang/introduction/introduction.scrbl
@@ -47,6 +47,7 @@ Running @code{encorec foo.enc} will typecheck the source and produce the executa
 @item{@code{-nogc} -- Disable the garbage collection of passive objects.}
 @item{@code{-help} -- Prints a help message and then exits.}
 @item{@code{-I path1:path2:...} -- Directories in which to look for modules. (Not needed for modules which are in the current folder.)}
+@item{@code{-F [flags]} -- Provides additional flags to the C compiler. Nessesary when using some C libraries. Use quatitionmarks to add more than one.}
 ]
 
 For instance, we might want to keep the intermediate C-files:


### PR DESCRIPTION
Added the -F flag to the encore compiler which
is used to provide additional flags to the C compiler.
This is vital when one uses C libraries that are not
included by default.

I added this since I'm currently working on a graphics library that uses SDL2.
Before I implemented this flag I always had to manually change the generated Makefile
to add `-lSDL2` to make the program compile.
But with the new flag I can just compile with `-F "-lSDL2".` 

This may not be the most desirable solution but it was easy to implement and solves the problem.

I have not figured out a nice way to test this.

This solves issue #565 
