### PR TITLE
Make sure embedded types have the same kind

### DIFF
--- a/src/tests/encore/basic/array_assign.enc
+++ b/src/tests/encore/basic/array_assign.enc
@@ -1,0 +1,41 @@
+trait S
+trait T
+
+typedef MyType = embed my_c_type end
+
+class Foo<t>
+  f: [embed my_c_type end]
+  g: [Range]
+  h: [Maybe int]
+  i: [T]
+  j: [S + T]
+  k: [t]
+  l: [int -> void]
+  m: [Fut int]
+  n: [Par int]
+  o: [Stream int]
+  p: [[int]]
+  q: [(int, Maybe int)]
+  r: [MyType]
+  s: [int]
+  def init(): void {
+    this.f = new [embed my_c_type end](42);
+    this.g = new [Range](42);
+    this.h = new [Maybe int](42);
+    this.i = new [T](42);
+    this.j = new [T + S](42);
+    this.k = new [t](42);
+    this.l = new [int -> void](42);
+    this.m = new [Fut int](42);
+    this.n = new [Par int](42);
+    this.o = new [Stream int](42);
+    this.p = new [[int]](42);
+    this.q = new [(int, Maybe int)](42);
+    this.r = new [MyType](42);
+    this.s = new [int](42);
+  }
+
+class Main
+  def main() : void {
+    print "I compile and run!"
+  }

--- a/src/tests/encore/basic/array_assign.out
+++ b/src/tests/encore/basic/array_assign.out
@@ -1,0 +1,1 @@
+I compile and run!

--- a/src/types/Types.hs
+++ b/src/types/Types.hs
@@ -282,7 +282,9 @@ hasSameKind ty1 ty2
     areBoth isTupleType ||
     areBoth isTypeVar ||
     areBoth isRefType ||
-    areBoth isArrowType = True
+    areBoth isArrowType ||
+    areBoth isRangeType ||
+    areBoth isCType = True
   | otherwise = False
   where
     isBottomTy1 = isBottomType ty1


### PR DESCRIPTION
This commit fixes a bug where checking if two embedded types had the
same kind would fail. For example, when assigning `x = y`, `x` and `y`
must be of the same kind. If `x` is an array of type `[t]`, `y` must be
an array of type `[t']` that where `t'` has the same kind as `t`. If `t`
was an embedded type, this would fail.

Fixes #575.
