### PR TITLE
Get rid of warning on implicit upcasts

### DIFF
--- a/src/back/CodeGen/Function.hs
+++ b/src/back/CodeGen/Function.hs
@@ -109,7 +109,7 @@ instance Translatable A.Function (ProgramTable -> CCode Toplevel) where
           funType   = A.functionType fun
           encArgNames = map A.pname funParams
           argNames  = map (AsLval . argName) encArgNames
-          paramTypesDecl = (\x y -> Decl (x, y))
+          paramTypesDecl = curry Decl
                            <$> [Ptr ponyTypeT]
                            <*> map (AsLval . typeVarRefName) funTypeParams
           assignRuntimeFn p i = Assign p (ArrAcc i encoreRuntimeType)
@@ -122,10 +122,10 @@ instance Translatable A.Function (ProgramTable -> CCode Toplevel) where
           tasks = map (\tas -> translateTask tas table) $
                       reverse $ Util.filter A.isTask funbody
           bodyResult = (Seq $ runtimeTypeAssignments ++
-                             [bodyStat, returnStmnt bodyName funType])
+                             [bodyStat, returnStatement funType bodyName])
       in
         Concat $ closures ++ tasks ++ [globalFunction fun (Just bodyResult)]
-    where
-      returnStmnt var ty
-          | isVoidType ty = Return $ AsExpr unit
-          | otherwise     = Return $ Cast (translate ty) var
+
+returnStatement ty var
+    | isVoidType ty = Return $ AsExpr unit
+    | otherwise     = Return $ Cast (translate ty) var

--- a/src/back/CodeGen/MethodDecl.hs
+++ b/src/back/CodeGen/MethodDecl.hs
@@ -9,6 +9,7 @@ import CodeGen.Expr ()
 import CodeGen.Closure
 import CodeGen.Task
 import CodeGen.ClassTable
+import CodeGen.Function(returnStatement)
 import qualified CodeGen.Context as Ctx
 
 import CCode.Main
@@ -44,13 +45,10 @@ instance Translatable A.MethodDecl (A.ClassDecl -> ProgramTable -> CCode Topleve
                if A.isMainMethod cname mName && null argNames
                then [(array, Var "_argv")]
                else zip argTypes argNames
-        retStmt = Return $ if Ty.isVoidType mType
-                           then AsExpr unit
-                           else Cast returnType bodyn
     in
       Concat $ closures ++ tasks ++
                [Function returnType name args
-                 (Seq [extractTypeVars, bodys, retStmt])]
+                 (Seq [extractTypeVars, bodys, returnStatement mType bodyn])]
     where
       mName = A.methodName mdecl
       mType = A.methodType mdecl


### PR DESCRIPTION
This commit gets rid of the C-level warning when returning a value that
is a supertype of the expected return type:

```
trait T
passive class Foo : T

def foo(): T
  new Foo() -- implicit upcast
```

There are no test cases as we have no way of checking for warning output
from the C compiler.
