### PR TITLE
Let traits with closures be multiply included

### DIFF
--- a/src/back/CodeGen/Closure.hs
+++ b/src/back/CodeGen/Closure.hs
@@ -59,7 +59,7 @@ translateClosure closure typeVars table
        in
          Concat [buildEnvironment envName freeVars fTypeVars,
                  tracefunDecl traceName envName freeVars,
-                 Function (Typ "value_t") funName
+                 Function (Static $ Typ "value_t") funName
                           [(Ptr (Ptr encoreCtxT), encoreCtxVar),
                            (Ptr (Ptr ponyTypeT), encoreRuntimeType),
                            (Typ "value_t", Var "_args[]"),
@@ -107,7 +107,7 @@ translateClosure closure typeVars table
               (Deref $ Cast (Ptr $ Struct envName) (Var "_env")) `Dot` name
 
       tracefunDecl traceName envName members =
-        Function void traceName args body
+        Function (Static void) traceName args body
         where
           args = [(Ptr encoreCtxT, ctxArg), (Ptr void, Var "p")]
           ctxArg = Var "_ctx_arg"

--- a/src/tests/encore/basic/trait_closure.enc
+++ b/src/tests/encore/basic/trait_closure.enc
@@ -1,0 +1,16 @@
+trait T
+  def getClosure() : () -> void
+    \ () -> print "You have finally reached closure!"
+
+passive class Foo : T
+passive class Bar : T
+
+class Main
+  def main() : void {
+    let x = new Foo();
+    let y = new Bar();
+    let f1 = x.getClosure();
+    let f2 = y.getClosure();
+    f1();
+    f2();
+  }

--- a/src/tests/encore/basic/trait_closure.out
+++ b/src/tests/encore/basic/trait_closure.out
@@ -1,0 +1,2 @@
+You have finally reached closure!
+You have finally reached closure!


### PR DESCRIPTION
This commit fixes the error where a trait defining a closure would cause
a linking error when included multiple times. This was because the
function representing the closure body was created once for each
including class (due to flattening). The solution was to make these
functions `static`, which also makes sense as they are method local.

Fixes #353.
