### PR TITLE
Let if-then statements have non-void type

### DIFF
--- a/src/tests/encore/basic/ifThen.enc
+++ b/src/tests/encore/basic/ifThen.enc
@@ -1,5 +1,7 @@
 class Main
   def main() : void{
+    (if true then 42) : void;
+
     if true then
       print "Hello Ponyworld 1!";
 

--- a/src/types/Typechecker/Typechecker.hs
+++ b/src/types/Typechecker/Typechecker.hs
@@ -707,9 +707,9 @@ instance Checkable Expr where
                     Nothing -> do
                       ty1Sub <- ty1 `subtypeOf` ty2
                       ty2Sub <- ty2 `subtypeOf` ty1
-                      if ty1Sub
+                      if ty1Sub || isVoidType ty2
                       then return ty2
-                      else if ty2Sub
+                      else if ty2Sub || isVoidType ty1
                            then return ty1
                            else tcError $ IfBranchMismatchError ty1 ty2
 


### PR DESCRIPTION
This commit changes the typechecking of if-expressions so that the
resulting type is `void` if either branch is `void`. This permits the
following program

```
if true then 42
```

which would otherwise throw a typechecking error as it is
desugared into

```
if true then 42 else ()
```

Fixes #594.
