### PR TITLE
Fix #609 add array bound check

### DIFF
--- a/src/runtime/array/array.c
+++ b/src/runtime/array/array.c
@@ -113,6 +113,7 @@ inline size_t array_size(array_t *a)
 
 inline encore_arg_t array_get(array_t *a, size_t i)
 {
+  assert(i < ((struct array_t *)a)->size);
   return ((struct array_t *)a)->elements[i];
 }
 


### PR DESCRIPTION
This PR adds a run-time check for looking up elements in an array. This is only turned on when the compiler/run-time is build with config=debug. 

In the future, bounds checks will be added at the compiler.

And there will be two functions for accessing elements. One that checks bounds and one that does not.