### PR TITLE
Support for immutable variables

### DIFF
--- a/emacs/encore-mode.el
+++ b/emacs/encore-mode.el
@@ -54,6 +54,7 @@
         "typedef"
         "unless"
         "val"
+        "var"
         "when"
         "while"
         "with"

--- a/modules/standard/StreamLib/StreamChain/StreamChain.enc
+++ b/modules/standard/StreamLib/StreamChain/StreamChain.enc
@@ -12,10 +12,10 @@ def chain<a,b>(sa:Stream a, f:a->b) : Stream b {
         end;
       }
       else {
-        let va = embed a (encore_arg_t)scons_element(_ctx,(struct scons*)#{scons}).p; end;
-        let nexta = embed Stream a scons_next(_ctx,(struct scons*)#{scons}); end;
-        let vb = f(va);
-        let nextb = chain<a,b>(nexta,f);
+        val va = embed a (encore_arg_t)scons_element(_ctx,(struct scons*)#{scons}).p; end;
+        val nexta = embed Stream a scons_next(_ctx,(struct scons*)#{scons}); end;
+        val vb = f(va);
+        val nextb = chain<a,b>(nexta,f);
         embed Scons
           scons_put_fut(_ctx,#{nextb},(encore_arg_t)#{vb}, _enc__type_b);
         end;

--- a/modules/standard/String.enc
+++ b/modules/standard/String.enc
@@ -213,11 +213,10 @@ passive class String
   def occurrences(s:String) : int
     if s.length() == 0
     then this.length()
-    else let
-      counter = 0
-      i       = this.find(s)
-      s_len   = s.length()
-    in {
+    else {
+      var counter = 0;
+      var i       = this.find(s);
+      val s_len   = s.length();
       while i >= 0 { counter = counter + 1; i = this.find_from(s, i + s_len); };
       counter
     }
@@ -229,14 +228,12 @@ passive class String
   def join(strings:[String]) : String
     if |strings| == 0
     then ""
-    else
-      let
-        result = strings[0]
-      in {
-        for i in [1..|strings|-1]
-          result = result.concatenate(this).concatenate(strings[i]);
-        result;
-      }
+    else {
+      var result = strings[0];
+      for i in [1..|strings|-1]
+        result = result.concatenate(this).concatenate(strings[i]);
+      result;
+    }
 
   def getData(): embed char* end
      this.data
@@ -342,25 +339,23 @@ passive class String
           s_arr[i] = string_from_char(match this.char_at(i) with Just c => c);
         s_arr
       }
-    else
-      let
-        result = new [String](occurrences + 1)
-        start  = 0
-        stop   = 0
-      in {
-        repeat i <- occurrences {
-          stop = this.find_from(p, start);
-          result[i] = match this.substring(start, stop) with Just s => s;
-          start = stop + pattern_len;
-        };
-        result[occurrences] = match this.substring(start, this.length()) with Just s => s;
-        result;
-      }
+    else {
+      val result = new [String](occurrences + 1);
+      var start  = 0;
+      var stop   = 0;
+      repeat i <- occurrences {
+        stop = this.find_from(p, start);
+        result[i] = match this.substring(start, stop) with Just s => s;
+        start = stop + pattern_len;
+      };
+      result[occurrences] = match this.substring(start, this.length()) with Just s => s;
+      result;
+    }
 
   def to_int() : Maybe int {
-    let s = this.data;
-    let n = 0;
-    let success = false;
+    val s = this.data;
+    val n = 0;
+    val success = false;
     embed void
       char *s = #{s};
       char *endptr;

--- a/src/ir/AST/AST.hs
+++ b/src/ir/AST/AST.hs
@@ -280,11 +280,11 @@ instance HasMeta TraitDecl where
     t{tmeta = AST.Meta.setType ty tmeta, tname = ty}
   showWithKind Trait{tname} = "trait '" ++ getId tname ++ "'"
 
-data Modifier = Val
+data Modifier = MVal
                 deriving(Eq)
 
 instance Show Modifier where
-    show Val = "val"
+    show MVal = "val"
 
 data FieldDecl = Field {
   fmeta :: Meta FieldDecl,
@@ -309,7 +309,7 @@ instance HasMeta FieldDecl where
     showWithKind Field{fname} = "field '" ++ show fname ++ "'"
 
 isValField :: FieldDecl -> Bool
-isValField = (Val `elem`) . fmods
+isValField = (MVal `elem`) . fmods
 
 data ParamDecl = Param {
   pmeta :: Meta ParamDecl,
@@ -396,6 +396,9 @@ type Arguments = [Expr]
 data MaybeContainer = JustData { e :: Expr}
                     | NothingData deriving(Eq, Show)
 
+data Mutability = Var
+                | Val deriving(Eq, Show)
+
 data Expr = Skip {emeta :: Meta Expr}
           | TypedExpr {emeta :: Meta Expr,
                        body :: Expr,
@@ -447,9 +450,11 @@ data Expr = Skip {emeta :: Meta Expr}
           | FinishAsync {emeta :: Meta Expr,
                          body :: Expr}
           | Let {emeta :: Meta Expr,
+                 mutability :: Mutability,
                  decls :: [(Name, Expr)],
                  body :: Expr}
           | MiniLet {emeta :: Meta Expr,
+                     mutability :: Mutability,
                      decl :: (Name, Expr)}
           | Seq {emeta :: Meta Expr,
                  eseq :: [Expr]}

--- a/src/tests/encore/basic/activeThis.enc
+++ b/src/tests/encore/basic/activeThis.enc
@@ -9,11 +9,11 @@ class Foo
       that.fr0b();
     }
 
-  def bar() : Fut bool
-    let that = null : Foo in{
-      that = this;
-      that.fr0b()
-    }
+  def bar() : Fut bool {
+    var that = null : Foo;
+    that = this;
+    that.fr0b();
+  }
 
   def baz() : Fut bool
     let that = id<Foo>(this)

--- a/src/tests/encore/basic/argAssign.enc
+++ b/src/tests/encore/basic/argAssign.enc
@@ -1,0 +1,7 @@
+def foo(x : int) : void
+  x = 42
+
+class Main
+  def main() : void {
+    ()
+  }

--- a/src/tests/encore/basic/argAssign.fail
+++ b/src/tests/encore/basic/argAssign.fail
@@ -1,0 +1,1 @@
+Variable 'x' is immutable and cannot be re-assigned

--- a/src/tests/encore/basic/closureCaptureAssign.enc
+++ b/src/tests/encore/basic/closureCaptureAssign.enc
@@ -1,0 +1,5 @@
+class Main
+  def main() : void {
+    var x = 42;
+    val f = \ (y : int) -> {x = 3; x};
+  }

--- a/src/tests/encore/basic/closureCaptureAssign.fail
+++ b/src/tests/encore/basic/closureCaptureAssign.fail
@@ -1,0 +1,1 @@
+Variable 'x' is immutable and cannot be re-assigned

--- a/src/tests/encore/basic/closure_shadowing.enc
+++ b/src/tests/encore/basic/closure_shadowing.enc
@@ -1,6 +1,6 @@
 class Main
   def main() : void {
-    let x = 41;
-    let f = \ () -> {let x = x + 1; x};
+    val x = 41;
+    val f = \ () -> {val x = x + 1; x};
     print f();
   }

--- a/src/tests/encore/basic/funSubtyping.enc
+++ b/src/tests/encore/basic/funSubtyping.enc
@@ -15,8 +15,8 @@ passive class Cat : Animal
 
 class Main {
   def main() : void {
-    let f = fun : Cat -> Animal;
-    let animal = f(new Cat);
+    val f = fun : Cat -> Animal;
+    val animal = f(new Cat);
     animal.speak();
   }
 }

--- a/src/tests/encore/basic/functionCast.enc
+++ b/src/tests/encore/basic/functionCast.enc
@@ -4,7 +4,7 @@ def fun() : (String, String) {
 
 class Main {
   def main() : void {
-    let foo = fun : () -> (String, String);
+    val foo = fun : () -> (String, String);
     match foo() with
       (h, w) => println("{} {}", h, w)
   }

--- a/src/tests/encore/basic/higherOrderCheck.enc
+++ b/src/tests/encore/basic/higherOrderCheck.enc
@@ -4,7 +4,7 @@ class Main {
   }
 
   def main() : void {
-    let f = \ (x: int) -> 2*x;
+    val f = \ (x: int) -> 2*x;
     this.higherOrder(f);
   }
 }

--- a/src/tests/encore/basic/lambda.enc
+++ b/src/tests/encore/basic/lambda.enc
@@ -42,7 +42,7 @@ class Main
   funFun : (int -> (int -> int))
 
   def free() : void {
-    let f = \() -> {
+    val f = \() -> {
       for i in [0..5] {
         print i;
       }

--- a/src/tests/encore/basic/let-arguments.enc
+++ b/src/tests/encore/basic/let-arguments.enc
@@ -1,11 +1,10 @@
 class Main
-  def main() : void 
+  def main() : void
     this.test(2)
-  def test(value : int) : void
-    let i = value in
-      while i < 11
-        {
-	  print i;
-          i = i + value;
-        }
-
+  def test(value : int) : void {
+    var i = value;
+    while i < 11 {
+        print i;
+        i = i + value;
+      }
+    }

--- a/src/tests/encore/basic/let-fields.enc
+++ b/src/tests/encore/basic/let-fields.enc
@@ -2,15 +2,14 @@ class Main
   value : int
   def main() : void {
     this.value = 1024;
-    let x = this.value in {
-      x = x + 1;
-      if x == 1024 then
-        print "Failue when reading x -- got 1024, expected something else"
-      else
-        print "Test 1 OK";
-      if x == this.value then
-        print "Failue when comparing x and this.value -- they are the same but should not be"
-      else
-        print "Test 2 OK";
-    }
+    var x = this.value;
+    x = x + 1;
+    if x == 1024 then
+      print "Failue when reading x -- got 1024, expected something else"
+    else
+      print "Test 1 OK";
+    if x == this.value then
+      print "Failue when comparing x and this.value -- they are the same but should not be"
+    else
+      print "Test 2 OK";
   }

--- a/src/tests/encore/basic/match.enc
+++ b/src/tests/encore/basic/match.enc
@@ -90,19 +90,19 @@ class NumberStreamer
     ()
 
   stream multiples(1 : int, limit : int) : int {
-    let i = 0 in
-      while i < limit {
-        yield i;
-        i = i + 1;
-      }
+    var i = 0;
+    while i < limit {
+      yield i;
+      i = i + 1;
     }
-  |      multiples(n : int, limit : int) : int {
-    let i = 0 in
-      while i < limit {
-        yield i;
-        i = i + n;
-      }
+  }
+  | multiples(n : int, limit : int) : int {
+    var i = 0;
+    while i < limit {
+      yield i;
+      i = i + n;
     }
+  }
 
 class Main {
   def objectPatternTestWithFailingGuard() : void
@@ -130,15 +130,14 @@ class Main {
   def matchingOnFunctionHead() : void
     print fac(5)
 
-  def matchingOnStreamHead() : void
-    let x = new NumberStreamer
-        evens = x.multiples(2, 10)
-    in{
-      while (not eos evens) {
-        print get evens;
-        evens = getNext evens
-      }
+  def matchingOnStreamHead() : void {
+    val x = new NumberStreamer;
+    var evens = x.multiples(2, 10);
+    while (not eos evens) {
+      print get evens;
+      evens = getNext evens
     }
+  }
 
   def objectPatternsInFunctionHead() : void
     expectEven(new IntContainer(4))
@@ -147,7 +146,7 @@ class Main {
   def variablePatternAgainstLambda() : void
     let f = \(x : int) -> x in
       match f with
-	x => print "foo"
+        x => print "foo"
 
   def main() : void {
     this.objectPatternTestWithFailingGuard();

--- a/src/tests/encore/basic/maybeTuple.enc
+++ b/src/tests/encore/basic/maybeTuple.enc
@@ -76,19 +76,18 @@ def test_unification_last_expression() : Maybe (int,int)
 -- Test multiple assignments and changes between them
 --
 def test_multiple_assignments(x: Maybe (int,int)) : (int,int) {
-  let y = Nothing : Maybe (int,int)
-      z = Just((32,32))
-  in {
-    x = y;
-    y = (Just (23,23));
-    y = x;
-    y = z;
-    x = Nothing : Maybe (int,int);
-    y;
-    match x with {
-      Just(z) => (23,23)
-        Nothing => (34,34)
-    }
+  var x' = x;
+  var y = Nothing : Maybe (int,int);
+  val z = Just((32,32));
+  x' = y;
+  y = (Just (23,23));
+  y = x;
+  y = z;
+  x' = Nothing : Maybe (int,int);
+  y;
+  match x with {
+    Just(z) => (23,23)
+    Nothing => (34,34)
   }
 }
 
@@ -103,7 +102,6 @@ class Main
    let
      x = Just((32,32))
      poly = new Poly<(int,int)>
-     -- u = foo(Just (32,32))
    in {
      print test_catch_all(x);
      print test_catch_specific_val(x);

--- a/src/tests/encore/basic/maybeType.enc
+++ b/src/tests/encore/basic/maybeType.enc
@@ -85,36 +85,20 @@ def test_unification_last_expression(x: Maybe int) : Maybe int
 -- Test multiple assignments and changes between them
 --
 def test_multiple_assignments(x: Maybe int) : int {
-  let y = Nothing : Maybe int
-      z = Just(32)
-  in {
-    x = y;
-    y = (Just 23);
-    y = x;
-    y = z;
-    x = Nothing : Maybe int;
-    y;
-    match x with {
-    	Just(z) => 23
-        Nothing => 34
-    }
+  var x' = x;
+  var y = Nothing : Maybe int;
+  val z = Just(32);
+  x' = y;
+  y = (Just 23);
+  y = x;
+  y = z;
+  x' = Nothing : Maybe int;
+  y;
+  match x with {
+      Just(z) => 23
+      Nothing => 34
   }
 }
-
--- def bad2() : Maybe int
---   let x = Just(42)
---       y = Nothing : Maybe String
---   in{
---       y = Just 42;
---       y
---   }
-
--- def bad1() : void
---   let y = Nothing : Maybe (Maybe ThisTypeDoesNotExist) in
---         ()
-
--- def foo(x : Maybe String) : Maybe int
---   x
 
 passive class Poly<t> {
   def morphic(x: t): Maybe t {
@@ -127,7 +111,6 @@ class Main
    let
      x = Just(32)
      poly = new Poly<int>
-     -- u = foo(Just 32)
    in {
 
      print test_catch_all(x);

--- a/src/tests/encore/basic/miniLet.enc
+++ b/src/tests/encore/basic/miniLet.enc
@@ -1,7 +1,7 @@
 class Main
   def main() : void {
-    let x = 42;
+    val x = 42;
     println("x = {}", x);
-    let f = \ (x : int) -> x + 1;
+    val f = \ (x : int) -> x + 1;
     println("f(x) = {}", f(x));
   }

--- a/src/tests/encore/basic/negation.enc
+++ b/src/tests/encore/basic/negation.enc
@@ -1,8 +1,8 @@
 class Main {
   def main() : void {
-    let x = -(-42);
-    let y = -(-(-x));
-    let z = -y + (-(1+2) + 3);
+    val x = -(-42);
+    val y = -(-(-x));
+    val z = -y + (-(1+2) + 3);
     print z;
   }
 }

--- a/src/tests/encore/basic/null.enc
+++ b/src/tests/encore/basic/null.enc
@@ -1,20 +1,19 @@
 def foo() : Foo{
-  let x = 42 in
-    while x < 0 {
-      x = x - 1;
-      null;
-    }
+  var x = 42;
+  while x < 0 {
+    x = x - 1;
+    null;
   }
+}
 
 class Foo
 
 class Main
-  def main() : void
-    let x = null : Foo
-        y = Just (null : Foo)
-        f = \ () -> null : Foo
-    in {
-      null : Foo;
-      x = foo();
-      print "I ain't scared of no null!";
-    }
+  def main() : void {
+    var x = null : Foo;
+    val y = Just (null : Foo);
+    val f = \ () -> null : Foo;
+    null : Foo;
+    x = foo();
+    print "I ain't scared of no null!";
+  }

--- a/src/tests/encore/basic/operator_precedence.enc
+++ b/src/tests/encore/basic/operator_precedence.enc
@@ -3,7 +3,7 @@ class Main
   def main() : void {
     print((123 == 100+23 and 789 <= 888) and ((123 == (100+23)) and (789 <= 888)));
     print((1+1 == 2 == true or false) and (((1+1 == 2) == true) or false)) ;
-    let a = Just 45;
-    let b = Nothing : Maybe int;
+    val a = Just 45;
+    val b = Nothing : Maybe int;
     print((a != Nothing and b == Nothing) and ((a != Nothing) and (b == Nothing)))
   }

--- a/src/tests/encore/basic/polymorphic_eq.enc
+++ b/src/tests/encore/basic/polymorphic_eq.enc
@@ -13,7 +13,7 @@ passive class Pair<k,v>
 
 class Main
   def main() : void {
-    let first = new Pair<int,int>(1,1);
-    let second = new Pair<int,int>(1,1);
+    val first = new Pair<int,int>(1,1);
+    val second = new Pair<int,int>(1,1);
     first.compare(second);
   }

--- a/src/tests/encore/basic/primeNames.enc
+++ b/src/tests/encore/basic/primeNames.enc
@@ -11,11 +11,11 @@ class Baz'<t'>
 
 class Main
   def main() : void {
-    let foo = new Foo'<int>;
-    let baz = new Baz'<Foo'<int>>;
-    let x = "This";
-    let x' = "is";
-    let x'' = "prime";
-    let x''' = "stuff!";
+    val foo = new Foo'<int>;
+    val baz = new Baz'<Foo'<int>>;
+    val x = "This";
+    val x' = "is";
+    val x'' = "prime";
+    val x''' = "stuff!";
     println("{} {} {} {}", x, x', x'', x''')
   }

--- a/src/tests/encore/basic/printf.enc
+++ b/src/tests/encore/basic/printf.enc
@@ -3,7 +3,7 @@ class Main
     for i in [1..9] {
       println("The square of {} is {}", i, i*i);
     };
-    let row = [false, true];
+    val row = [false, true];
     for b1 in row {
       for b2 in row {
         println("{} | {}", (b1, b2), b1 and b2);

--- a/src/tests/encore/basic/real.enc
+++ b/src/tests/encore/basic/real.enc
@@ -3,7 +3,7 @@ def foo(x : real) : real
 
 class Main
   def main() : void {
-    let pi = 3.141593;
+    val pi = 3.141593;
     println("Pi is something like {}", pi);
     println("Ints can be promoted to reals: {}", foo(42))
   }

--- a/src/tests/encore/basic/refreshContext.enc
+++ b/src/tests/encore/basic/refreshContext.enc
@@ -10,11 +10,11 @@ class Test
 
 class Main
   def main(): void{
-    let v = 0;
+    var v = 0;
     repeat i <- 1000 {
-      let t = new Test;
+      val t = new Test;
       get t.f();
-      let f = \(x:int) -> id(x);
+      val f = \(x:int) -> id(x);
       v = v + get t.g(f);
     };
     print v;

--- a/src/tests/encore/basic/streams.enc
+++ b/src/tests/encore/basic/streams.enc
@@ -1,22 +1,24 @@
 class Streamer
   stream even(n : int) : int{
-    let i = 0 in
-      while i < n{
-        yield i;
-        i = i + 2;
-      }
+    var i = 0;
+    while i < n {
+      yield i;
+      i = i + 2;
+    }
   }
 
   stream odd(n : int) : int{
-    let i = 1 in
-      while i < n{
-        yield i;
-        i = i + 2;
-      }
+    var i = 1;
+    while i < n{
+      yield i;
+      i = i + 2;
+    }
   }
 
 class Combinator
   stream interleave(s1 : Stream int, s2 : Stream int) : int{
+    var s1 = s1;
+    var s2 = s2;
     while ((not eos s1) and (not eos s2)) {
       yield get s1;
       yield get s2;
@@ -26,16 +28,15 @@ class Combinator
   }
 
 class Main
-  def main() : void
-    let x = new Streamer
-        even = x.even(10)
-        odd  = x.odd(10)
-        c = new Combinator
-        range = c.interleave(even, odd)
-    in{
-      while (not eos range){
-        print get range;
-        range = getNext range;
-      };
-      print "Done!"
-    }
+  def main() : void {
+    val x = new Streamer;
+    val even = x.even(10);
+    val odd  = x.odd(10);
+    val c = new Combinator;
+    var range = c.interleave(even, odd);
+    while (not eos range) {
+      print get range;
+      range = getNext range;
+    };
+    print "Done!"
+  }

--- a/src/tests/encore/basic/stringTrace.enc
+++ b/src/tests/encore/basic/stringTrace.enc
@@ -1,6 +1,6 @@
 class Foo
   def foo() : String {
-    let s =
+    val s =
       embed (embed char* end)
         char *s = encore_alloc(*_ctx, 1000);
         strcpy(s, "Hello");
@@ -11,9 +11,9 @@ class Foo
 
 class Main
   def main() : void {
-    let x = new Foo();
+    val x = new Foo();
     for i in [0..20] {
-      let s = get x.foo();
+      val s = get x.foo();
       println("{} {}", s, i);
     };
   }

--- a/src/tests/encore/basic/uint.enc
+++ b/src/tests/encore/basic/uint.enc
@@ -5,7 +5,7 @@ def addUnsigned(x : uint, y : int) : uint {
 class Main
   def main() : void {
     print addUnsigned(42u, 13u);
-    let large =
+    val large =
           embed uint
             unsigned long long x = 1ul << 32 << 31;
             x;

--- a/src/tests/encore/basic/unit.enc
+++ b/src/tests/encore/basic/unit.enc
@@ -4,13 +4,12 @@ class Foo
     print "Got unit"
 
 class Main
-  def main() : void
-    let unit1 = ()
-        unit2 = ()
-        x = new Foo
-        f = \(x : void) -> {print "Got unit"; x}
-    in
-      {x.foo(unit1);
-       f(unit2);
-       unit1 = unit2
-      }
+  def main() : void {
+    var unit1 = ();
+    val unit2 = ();
+    val x = new Foo;
+    val f = \(x : void) -> {print "Got unit"; x};
+    x.foo(unit1);
+    f(unit2);
+    unit1 = unit2;
+  }

--- a/src/tests/encore/basic/valAssign.enc
+++ b/src/tests/encore/basic/valAssign.enc
@@ -1,0 +1,5 @@
+class Main
+  def main() : void {
+    val x = 42;
+    x = 0;
+  }

--- a/src/tests/encore/basic/valAssign.fail
+++ b/src/tests/encore/basic/valAssign.fail
@@ -1,0 +1,1 @@
+Variable 'x' is immutable and cannot be re-assigned

--- a/src/tests/encore/basic/while.enc
+++ b/src/tests/encore/basic/while.enc
@@ -1,6 +1,8 @@
 class Main
-  def main() : void
-    let i = 3 in
-      while i > 0
-        {print "Hello Ponyworld!";
-         i = i - 1}
+  def main() : void {
+    var i = 3;
+    while i > 0 {
+      print "Hello Ponyworld!";
+      i = i - 1;
+    }
+  }

--- a/src/tests/encore/concurrency/future_run_closure.enc
+++ b/src/tests/encore/concurrency/future_run_closure.enc
@@ -23,12 +23,12 @@ class Test
 
 class Main
   def main(): void {
-    let t = new Test;
-    let t2 = new Test;
-    let f1 = t.createMoney();
+    val t = new Test;
+    val t2 = new Test;
+    val f1 = t.createMoney();
     await f1;
-    let f2 = f1 ~~> \(m: Money) -> { t2.update(m) ~~> \(m: Money) -> m };
+    val f2 = f1 ~~> \(m: Money) -> { t2.update(m) ~~> \(m: Money) -> m };
     await f2;
-    let money = get (get f2);
+    val money = get (get f2);
     print(money.amount)
   }

--- a/src/tests/encore/embed/embed_escaped.enc
+++ b/src/tests/encore/embed/embed_escaped.enc
@@ -4,13 +4,13 @@ passive class Foo
 class Main
   f : int
   def main(): void {
-    let x = new Foo();
-    let y = embed int
+    val x = new Foo();
+    val y = embed int
               #{embed int
                   #{embed int 21; end};
                 end};
             end;
-    let z = 0;
+    val z = 0;
     embed void
       int x = #{y} + 21;
       #{x.f} = x;

--- a/src/tests/encore/modules/StdLib.enc
+++ b/src/tests/encore/modules/StdLib.enc
@@ -1,4 +1,3 @@
-
 import Active.Active  -- imports from standard library
 
 passive class Greeter {
@@ -9,7 +8,7 @@ passive class Greeter {
 
 class Main {
   def main(): void {
-    let a = new Active<Greeter>(\ () -> new Greeter);
+    val a = new Active<Greeter>(\ () -> new Greeter);
     a.apply(\ (g:Greeter) -> { g.greet(); })
   }
 }

--- a/src/tests/encore/polyfun/array.enc
+++ b/src/tests/encore/polyfun/array.enc
@@ -19,21 +19,21 @@ def pExtractElementFromArray<t>(xs: [t]): t
 
 class Main
   def main() : void {
-    let test1 = pArrayLit<int, String>("Test array literals", 42, 12);
+    val test1 = pArrayLit<int, String>("Test array literals", 42, 12);
     repeat i <- |test1| { print(test1[i])};
 
-    let test2 = pArrayAccess<String>("Test array return type within parametric function");
+    val test2 = pArrayAccess<String>("Test array return type within parametric function");
     print(test2);
 
-    let test3 = pCreateParametricArray<String>("Test returns empty array of String type");
+    val test3 = pCreateParametricArray<String>("Test returns empty array of String type");
     test3[0] = "pCreateParametricArray";
     print(test3[0]);
 
-    let testPassingArray = pCreateTupleContainingArray<[String]>(["Test appending to existing array"], "True!");
+    val testPassingArray = pCreateTupleContainingArray<[String]>(["Test appending to existing array"], "True!");
     match testPassingArray with {
       (fst, snd) => repeat i <- |fst| { print("{} - {}\n", fst[i], snd);}
     };
 
-    let testExtractElement = pExtractElementFromArray<[String]>([["1", "2", "3"]]);
+    val testExtractElement = pExtractElementFromArray<[String]>([["1", "2", "3"]]);
     repeat i <- |testExtractElement| print(testExtractElement[i]);
   }

--- a/src/tests/encore/polyfun/array_inf.enc
+++ b/src/tests/encore/polyfun/array_inf.enc
@@ -19,21 +19,21 @@ def pExtractElementFromArray<t>(xs: [t]): t
 
 class Main
   def main() : void {
-    let test1 = pArrayLit("Test array literals", 42, 12);
+    val test1 = pArrayLit("Test array literals", 42, 12);
     repeat i <- |test1| { print(test1[i])};
 
-    let test2 = pArrayAccess("Test array return type within parametric function");
+    val test2 = pArrayAccess("Test array return type within parametric function");
     print(test2);
 
-    let test3 = pCreateParametricArray("Test returns empty array of String type");
+    val test3 = pCreateParametricArray("Test returns empty array of String type");
     test3[0] = "pCreateParametricArray";
     print(test3[0]);
 
-    let testPassingArray = pCreateTupleContainingArray(["Test appending to existing array"], "True!");
+    val testPassingArray = pCreateTupleContainingArray(["Test appending to existing array"], "True!");
     match testPassingArray with {
       (fst, snd) => repeat i <- |fst| { print("{} - {}\n", fst[i], snd);}
     };
 
-    let testExtractElement = pExtractElementFromArray([["1", "2", "3"]]);
+    val testExtractElement = pExtractElementFromArray([["1", "2", "3"]]);
     repeat i <- |testExtractElement| print(testExtractElement[i]);
   }

--- a/src/tests/encore/polyfun/classes.enc
+++ b/src/tests/encore/polyfun/classes.enc
@@ -24,12 +24,12 @@ class Test<a>
 
 class Main
   def main() : void {
-    let t = createTest<String>("Create Test of type 'String'");
+    val t = createTest<String>("Create Test of type 'String'");
     print(get t.getArg());
 
-    let arr = get t.appendToArray("Adding a new string");
+    val arr = get t.appendToArray("Adding a new string");
     repeat i <- |arr| { print(arr[i]);};
 
-    let tup = get t.toTuple("Adding to tuple");
+    val tup = get t.toTuple("Adding to tuple");
     print(tup);
   }

--- a/src/tests/encore/polyfun/classes_inf.enc
+++ b/src/tests/encore/polyfun/classes_inf.enc
@@ -24,12 +24,12 @@ class Test<a>
 
 class Main
   def main() : void {
-    let t = createTest("Create Test of type 'String'");
+    val t = createTest("Create Test of type 'String'");
     print(get t.getArg());
 
-    let arr = get t.appendToArray("Adding a new string");
+    val arr = get t.appendToArray("Adding a new string");
     repeat i <- |arr| { print(arr[i]);};
 
-    let tup = get t.toTuple("Adding to tuple");
+    val tup = get t.toTuple("Adding to tuple");
     print(tup);
   }

--- a/src/tests/encore/polyfun/functions.enc
+++ b/src/tests/encore/polyfun/functions.enc
@@ -24,10 +24,10 @@ def pNestedFunction<t>(x: t): t
 
 class Main
   def main() : void {
-    let test1 = pSingleArgument<String>("test single argument", 42, "single");
+    val test1 = pSingleArgument<String>("test single argument", 42, "single");
     print(test1);
 
-    let pNested = pNestedFunction<String>("test passing parametric type between parametric functions");
+    val pNested = pNestedFunction<String>("test passing parametric type between parametric functions");
     print(pNested);
 
     let testRecursiveName = "test calling function recursively"
@@ -38,6 +38,6 @@ class Main
          Nothing => print("Error in function pRecursiveCall, expected output: '{}'", testRecursiveName)
     };
 
-    let compFn = compose<String, String, String>(id<String>, id<String>);
+    val compFn = compose<String, String, String>(id<String>, id<String>);
     print compFn("42");
   }

--- a/src/tests/encore/polyfun/functions_inf.enc
+++ b/src/tests/encore/polyfun/functions_inf.enc
@@ -24,10 +24,10 @@ def pNestedFunction<t>(x: t): t
 
 class Main
   def main() : void {
-    let test1 = pSingleArgument("test single argument", 42, "single");
+    val test1 = pSingleArgument("test single argument", 42, "single");
     print(test1);
 
-    let pNested = pNestedFunction("test passing parametric type between parametric functions");
+    val pNested = pNestedFunction("test passing parametric type between parametric functions");
     print(pNested);
 
     let testRecursiveName = "test calling function recursively"
@@ -38,6 +38,6 @@ class Main
          Nothing => print("Error in function pRecursiveCall, expected output: '{}'", testRecursiveName)
     };
 
-    let compFn = compose(id<String>, id<String>);
+    val compFn = compose(id<String>, id<String>);
     print compFn("42");
   }

--- a/src/tests/encore/polyfun/maybe.enc
+++ b/src/tests/encore/polyfun/maybe.enc
@@ -18,13 +18,11 @@ class Main
         Nothing => print "Error: expected 'Just' value constructor but got 'Nothing'"
     };
 
-    let testNothing = fCreateParametricOptionTypeNothing<String>("Test the returns parametric Nothing")
-    in {
+    var testNothing = fCreateParametricOptionTypeNothing<String>("Test the returns parametric Nothing");
       match testNothing with
         Just s => print "Error, expected 'Nothing'"
         Nothing => { testNothing = Just "re-assignment";
-                     print "Test create parametric Nothing and can be re-assigned";}
-    };
+                     print "Test create parametric Nothing and can be re-assigned";};
 
     let testNewVal = extractAndCreateOptionValue<String>(Just "Remove this text", "Append this text")
     in {

--- a/src/tests/encore/polyfun/maybe_inf.enc
+++ b/src/tests/encore/polyfun/maybe_inf.enc
@@ -18,13 +18,11 @@ class Main
         Nothing => print "Error: expected 'Just' value constructor but got 'Nothing'"
     };
 
-    let testNothing = fCreateParametricOptionTypeNothing("Test the returns parametric Nothing")
-    in {
+    var testNothing = fCreateParametricOptionTypeNothing("Test the returns parametric Nothing");
       match testNothing with
         Just s => print "Error, expected 'Nothing'"
         Nothing => { testNothing = Just "re-assignment";
-                     print "Test create parametric Nothing and can be re-assigned";}
-    };
+                     print "Test create parametric Nothing and can be re-assigned";};
 
     let testNewVal = extractAndCreateOptionValue(Just "Remove this text", "Append this text")
     in {

--- a/src/tests/encore/polyfun/par.enc
+++ b/src/tests/encore/polyfun/par.enc
@@ -70,8 +70,8 @@ class Main
   def main() : void {
     let testSequence = sequencePipeline<int>(liftv 42)
         result = extractPar<String>(testSequence)
-    in { repeat i <- |result| print(result[i]);};
+    in {repeat i <- |result| print(result[i])};
 
-    let testJoin = extractPar<int>(joinParTest<int>(20));
+    val testJoin = extractPar<int>(joinParTest<int>(20));
     repeat i <- |testJoin| print(testJoin[i])
   }

--- a/src/tests/encore/polyfun/par_inf.enc
+++ b/src/tests/encore/polyfun/par_inf.enc
@@ -70,8 +70,8 @@ class Main
   def main() : void {
     let testSequence = sequencePipeline(liftv 42)
         result = extractPar(testSequence)
-    in { repeat i <- |result| print(result[i]);};
+    in { repeat i <- |result| print(result[i]) };
 
-    let testJoin = extractPar(joinParTest(20));
+    val testJoin = extractPar(joinParTest(20));
     repeat i <- |testJoin| print(testJoin[i])
   }

--- a/src/tests/encore/polyfun/tuple.enc
+++ b/src/tests/encore/polyfun/tuple.enc
@@ -7,13 +7,13 @@ def pFlipInTuple<a, b>(tuple: (a, b)): (b, a)
 
 class Main
   def main() : void {
-    let test1 = pCreateTuple<int, String>("k", 12);
+    val test1 = pCreateTuple<int, String>("k", 12);
     match test1 with {
       (k, v) => print("Parametric tuple with key: '{}' and value '{}'\n", k, v)
         _ => print("error in 'pMultipleParametricArguments'\n")
     };
 
-    let testFlipTuple = pFlipInTuple<String, int>(("Update tuple test", 23));
+    val testFlipTuple = pFlipInTuple<String, int>(("Update tuple test", 23));
     match testFlipTuple with
       (v, k) => print("Flipped key {} with value {}", k, v);
   }

--- a/src/tests/encore/polyfun/tuple_inf.enc
+++ b/src/tests/encore/polyfun/tuple_inf.enc
@@ -7,13 +7,13 @@ def pFlipInTuple<a, b>(tuple: (a, b)): (b, a)
 
 class Main
   def main() : void {
-    let test1 = pCreateTuple("k", 12);
+    val test1 = pCreateTuple("k", 12);
     match test1 with {
       (k, v) => print("Parametric tuple with key: '{}' and value '{}'\n", k, v)
         _ => print("error in 'pMultipleParametricArguments'\n")
     };
 
-    let testFlipTuple = pFlipInTuple(("Update tuple test", 23));
+    val testFlipTuple = pFlipInTuple(("Update tuple test", 23));
     match testFlipTuple with
       (v, k) => print("Flipped key {} with value {}", k, v);
   }

--- a/src/tests/encore/stdlib/Data/Either.enc
+++ b/src/tests/encore/stdlib/Data/Either.enc
@@ -1,11 +1,10 @@
 import Data.Either
 class Main
   def main() : void {
-    let l = Left<String,int>("error");
-    let r = Right<String,int>(12);
+    val l = Left<String,int>("error");
+    val r = Right<String,int>(12);
     l.map(\ (x:int) -> {print "should not print"; x});
     l.foreach(\ (x:int) -> print "should not print");
     r.map(\ (x:int) -> {print "should print"; x});
     r.foreach(\ (x:int) -> print "should print");
-
   }

--- a/src/tests/encore/stdlib/stringtest.enc
+++ b/src/tests/encore/stdlib/stringtest.enc
@@ -11,16 +11,14 @@ def strcmp(a:String, b:String) : bool
 
 def arraycmp(a:[String], b:[String]) : bool
   if |a| == |b|
-  then
-    let
-      same = true
-    in {
-      repeat i <- |a|
-        if not strcmp(a[i] , b[i]) then same = false;
-      same;
-    }
-    else
-      false
+  then {
+    var same = true;
+    repeat i <- |a|
+      if not strcmp(a[i] , b[i]) then same = false;
+    same;
+  }
+  else
+    false
 
 class Main
   def main() : void

--- a/src/tests/encore/stream/StreamIO.enc
+++ b/src/tests/encore/stream/StreamIO.enc
@@ -1,27 +1,35 @@
 module StreamIO
 
 class StreamIO {
-  stream produceInt(i : int) : int
+  stream produceInt(n : int) : int {
+    var i = n;
     while i>0 {
       yield i;
       i = i - 1;
     }
+  }
 
-  stream produceReal(i : int) : real
+  stream produceReal(n : int) : real {
+    var i = n;
     while i>0 {
       yield i*1.0;
       i = i - 1;
     }
+  }
 
-  def printStreamReal(sr : Stream real) : void
-    while (not eos sr) {
-      print(get sr);
-      sr = getNext sr;
+  def printStreamReal(sr : Stream real) : void {
+    var str = sr;
+    while (not eos str) {
+      print(get str);
+      str = getNext str;
     }
+  }
 
-  def printStreamInt(sr : Stream int) : void
-    while (not eos sr) {
-      print(get sr);
-      sr = getNext sr;
+  def printStreamInt(si : Stream int) : void {
+    var str = si;
+    while (not eos str) {
+      print(get str);
+      str = getNext str;
     }
+  }
 }

--- a/src/tests/encore/stream/streamEos.enc
+++ b/src/tests/encore/stream/streamEos.enc
@@ -8,7 +8,7 @@ class Foo
 
 class Main
   def main() : void {
-    let s = (new Foo).bar() in
+    var s = (new Foo).bar();
     while (not eos s) {
       print (get s);
       s = getNext s;

--- a/src/tests/encore/traits/traitMethodWithConcreteType.enc
+++ b/src/tests/encore/traits/traitMethodWithConcreteType.enc
@@ -22,7 +22,7 @@ passive class C : Foo<int> + Bar<String> {
 
 class Main {
   def main() : void {
-    let c = new C();
+    val c = new C();
     print c.getX();
     showBar(c);
   }

--- a/src/tests/encore/traits/traitProvide.enc
+++ b/src/tests/encore/traits/traitProvide.enc
@@ -18,7 +18,7 @@ passive class Counter: Inc + Get
 
 class Main
   def main(): void {
-    let x = new Counter(42) : Inc;
+    val x = new Counter(42) : Inc;
     print("The answer is {}\n", x.get_());
     x.inc();
     print("The answer is now {}\n", x.get_());

--- a/src/tests/encore/traits/traitProvideOverlap.enc
+++ b/src/tests/encore/traits/traitProvideOverlap.enc
@@ -20,7 +20,7 @@ passive class Counter: Inc + Get
 
 class Main
   def main(): void {
-    let x = new Counter(42) : Inc;
+    val x = new Counter(42) : Inc;
     print("The answer is {}\n", x.get_());
     x.inc();
     print("The answer is now {}\n", x.get_());

--- a/src/tests/encore/traits/traitProvideOverlapValVar.enc
+++ b/src/tests/encore/traits/traitProvideOverlapValVar.enc
@@ -19,7 +19,7 @@ passive class Counter: Inc + Get
 
 class Main
   def main(): void {
-    let x = new Counter(42) : Inc;
+    val x = new Counter(42) : Inc;
     print("The answer is {}\n", x.get_());
     x.inc();
     print("The answer is now {}\n", x.get_());

--- a/src/tests/encore/traits/traitProvidePoly.enc
+++ b/src/tests/encore/traits/traitProvidePoly.enc
@@ -13,6 +13,6 @@ passive class C : T<int> + U<int>
 
 class Main
   def main(args : [String]): void {
-    let x = new C(42) : T<int>;
+    val x = new C(42) : T<int>;
     print(x.foo());
   }

--- a/src/tests/encore/traits/trait_closure.enc
+++ b/src/tests/encore/traits/trait_closure.enc
@@ -7,10 +7,10 @@ passive class Bar : T
 
 class Main
   def main() : void {
-    let x = new Foo();
-    let y = new Bar();
-    let f1 = x.getClosure();
-    let f2 = y.getClosure();
+    val x = new Foo();
+    val y = new Bar();
+    val f1 = x.getClosure();
+    val f2 = y.getClosure();
     f1();
     f2();
   }

--- a/src/tests/encore/traits/traits.enc
+++ b/src/tests/encore/traits/traits.enc
@@ -28,11 +28,11 @@ trait Pop
 
 passive class Stack : Push + Pop
   top : Link
-  def steal(other : Pop) : void
-    let x = other in {
-      x = other;
-      this.push(x.pop())
-    }
+  def steal(other : Pop) : void {
+    var x = other;
+    x = other;
+    this.push(x.pop())
+  }
 
 class Driver
   myPop : Pop

--- a/src/tests/encore/union/ambiguous.enc
+++ b/src/tests/encore/union/ambiguous.enc
@@ -14,7 +14,7 @@ passive class C2 : Bar + Baz
 
 class Main
   def main(): void {
-    let x = if true then
+    val x = if true then
               new C1
             else
               new C2;

--- a/src/tests/encore/union/composite.enc
+++ b/src/tests/encore/union/composite.enc
@@ -15,7 +15,7 @@ passive class C2 : Foo + Bar
 
 class Main
   def main(): void {
-    let x = if true then
+    val x = if true then
               Just [new C1]
             else
               Just [new C2];

--- a/src/tests/encore/union/inference.enc
+++ b/src/tests/encore/union/inference.enc
@@ -15,12 +15,12 @@ passive class C3 : Baz + Foo
 
 class Main
   def main(): void{
-    let x = match 1 with
+    val x = match 1 with
               0 => new C1()
               1 => new C2()
               2 => new C3()
               3 => null;
-    let y = match 1 with
+    val y = match 1 with
               0 => Just new C1()
               1 => Just new C2()
               2 => Just new C3()

--- a/src/tests/encore/union/lub.enc
+++ b/src/tests/encore/union/lub.enc
@@ -15,7 +15,7 @@ passive class C3 : Foo
 
 class Main
   def main(): void{
-    let x = match 1 with
+    val x = match 1 with
               0 => new C1()
               1 => new C2()
               2 => new C3();

--- a/src/tests/encore/union/match.enc
+++ b/src/tests/encore/union/match.enc
@@ -15,7 +15,7 @@ passive class C3 : Baz + Foo
 
 class Main
   def main(): void{
-    let x = match 1 with
+    val x = match 1 with
               0 => new C1()
               1 => new C2()
               2 => new C3();

--- a/src/tests/encore/union/nested.enc
+++ b/src/tests/encore/union/nested.enc
@@ -19,7 +19,7 @@ passive class C3 : Foo + Frob
 
 class Main
   def main(): void {
-    let x = match 42 with
+    val x = match 42 with
               0 => new C1
               1 => if false then
                      new C2

--- a/src/tests/encore/union/pattern.enc
+++ b/src/tests/encore/union/pattern.enc
@@ -17,7 +17,7 @@ passive class C3 : Baz + Foo
 
 class Main
   def main(): void{
-    let x = match 1 with
+    val x = match 1 with
               0 => new C1()
               1 => new C2()
               2 => new C3();

--- a/src/tests/encore/union/simple.enc
+++ b/src/tests/encore/union/simple.enc
@@ -15,7 +15,7 @@ passive class C2 : Foo + Bar
 
 class Main
   def main(): void {
-    let x = if true then
+    val x = if true then
               new C1
             else
               new C2;

--- a/src/types/Typechecker/Prechecker.hs
+++ b/src/types/Typechecker/Prechecker.hs
@@ -172,7 +172,7 @@ instance Precheckable TraitDecl where
       where
         typeParameters = getTypeParameters tname
         addTypeParams = addTypeParameters typeParameters
-        addThis self = extendEnvironment [(thisName, self)]
+        addThis self = extendEnvironmentImmutable [(thisName, self)]
         assertDistinctness = do
           assertDistinctThing "declaration" "type parameter" typeParameters
           assertDistinct "declaration" treqs
@@ -196,7 +196,7 @@ instance Precheckable ClassDecl where
       where
         typeParameters = getTypeParameters cname
         addTypeParams = addTypeParameters typeParameters
-        addThis self = extendEnvironment [(thisName, self)]
+        addThis self = extendEnvironmentImmutable [(thisName, self)]
         assertDistinctness = do
             assertDistinctThing "declaration" "type parameter" typeParameters
             assertDistinctThing "inclusion" "trait" $

--- a/src/types/Typechecker/TypeError.hs
+++ b/src/types/Typechecker/TypeError.hs
@@ -191,6 +191,7 @@ data Error =
   | ActiveMatchError
   | MatchInferenceError
   | ThisReassignmentError
+  | ImmutableVariableError QualifiedName
   | PatternTypeMismatchError Expr Type
   | NonMaybeExtractorPatternError Expr
   | InvalidPatternError Expr
@@ -343,6 +344,9 @@ instance Show Error where
     show ActiveMatchError = "Cannot match on an active object"
     show MatchInferenceError = "Cannot infer result type of match expression"
     show ThisReassignmentError = "Cannot rebind variable 'this'"
+    show (ImmutableVariableError qname) =
+        printf "Variable '%s' is immutable and cannot be re-assigned"
+               (show qname)
     show (PatternTypeMismatchError pattern ty) =
         printf "Pattern '%s' does not match expected type '%s'"
                (show $ ppSugared pattern) (show ty)


### PR DESCRIPTION
This commit changes how variables are handled in Encore. There are three
ways of declaring variables:

```
let x = 42 in
  e
```

```
val x = 42;
```

```
var x = 42;
```

Names introduced with `let` or `val` are *immutable* and cannot be
re-assigned. Function, method and closure arguments, and names introduced
by `match`, `for` and `repeat` are also immutable, as are variables
captured by closures (regardless of how they were declared). Variables
introduced with `var` may be re-assigned. Objects referred to by
variables are not affected by the immutability of the variable.

Note that the old short-hand syntax `let x = 42;` has been replaced by
`val` and `var`. This will likely break existing programs! All tests have
been updated, and new ones have been added.