### PR TITLE
Fix bug in test script

### DIFF
--- a/src/tests/IGNORED_FILES.grep
+++ b/src/tests/IGNORED_FILES.grep
@@ -9,11 +9,11 @@ encore/modules/ClosureImporter
 encore/modules/ClosureImp
 encore/modules/DeepLib
 encore/modules/Lib
-encore/modules/lib/DupLib
-encore/modules/lib/FarLib
-encore/modules/lib/TraitLib
-encore/modules/lib/A/B/QLib
-encore/modules/otherlib/DupLib
+encore/modules/Lib/DupLib
+encore/modules/Lib/FarLib
+encore/modules/Lib/TraitLib
+encore/modules/Lib/A/B/QLib
+encore/modules/OtherLib/DupLib
 encore/modules/Vector
 encore/modules/Utils
 encore/modules/MidImport

--- a/src/tests/bin/test
+++ b/src/tests/bin/test
@@ -136,7 +136,7 @@ function have_at_least_one_spec_file() {
 #
 ############################################################
 function test_enabled() {
-    ! grep --invert-match "^#" < IGNORED_FILES.grep | grep $1 > /dev/null
+    ! grep --invert-match "^#" < IGNORED_FILES.grep | grep $1"$" > /dev/null
 }
 
 ############################################################

--- a/src/tests/encore/modules/TraitImportModule.enc
+++ b/src/tests/encore/modules/TraitImportModule.enc
@@ -1,3 +1,5 @@
+module TraitImportModule
+
 trait Reagent {
   def react() : void {
     ();


### PR DESCRIPTION
This commit fixes a bug where having an ignored file in a test suite
would prevent running that suite on its own. The important change is the
one in `src/tests/bin/test`. This also enables a test that was
previously erroneously disabled (and fixes a bug in that test).

The changes in `IGNORED_FILES.grep` are to get rid of some warnings.