### PR TITLE
Fixed missing switch case blocking compilation in GCC 6

### DIFF
--- a/src/runtime/future/future.c
+++ b/src/runtime/future/future.c
@@ -246,6 +246,10 @@ void future_fulfil(pony_ctx_t **ctx, future_t *fut, encore_arg_t value)
           pony_send_done(cctx);
           break;
         }
+      case BLOCKED_MESSAGE:
+        {
+          assert(false);
+        }
       }
       current = current->next;
     }


### PR DESCRIPTION
This PR adds
```
      case BLOCKED_MESSAGE:
        {
          assert(false);
        }
```
to `future.c` to make Encore compile when using GCC 6. This is needed because of a bug in GCC 6 according to @albertnetymk. 
