### PR TITLE
Fix bug using type parameters

### DIFF
--- a/src/back/CodeGen/Preprocessor.hs
+++ b/src/back/CodeGen/Preprocessor.hs
@@ -68,7 +68,7 @@ convertMethod bindings cdecl method =
             let f = A.name e
                 ty = getFieldType f (A.cfields cdecl)
             in A.setType ty $ convertNode e
-        | otherwise = convertNode e
+        | otherwise = convertNode $ Util.exprTypeMap convertType e
 
     isThisFieldAccess A.FieldAccess{A.target} = A.isThisAccess target
     isThisFieldAccess _ = False

--- a/src/tests/encore/traits/traits_polymorphic.enc
+++ b/src/tests/encore/traits/traits_polymorphic.enc
@@ -1,5 +1,23 @@
+def id<a>(x : a) : a
+  x
+
+class Foo<t>
+  def init(x : t) : void
+    ()
+
 trait T<t> {
   require x : t
+  def foo<t>() : void {
+    val arr = new [t](10);
+    val x = arr[0] : t;
+    new Foo<t>(x);
+    val f = id<t>;
+    f(x);
+    id(x);
+    embed t
+      #{x};
+    end;
+  }
 }
 
 passive class C : T<int> {


### PR DESCRIPTION
This commit fixes a bug found by @kaeluka in #608 where including 
a polymorphic trait `T<t>` as a concrete trait `T<int>` would not properly 
translate the runtime type parameter `t` when used in the methods of the 
trait. Test `traits_polymorphic.enc` has been updated to cover these cases.

The solution tries to be general enough so that only one place needs to
be changed when future AST nodes are added.