### PR TITLE
`this` cannot be re-assigned

### DIFF
--- a/src/tests/encore/basic/thisNotReassignable.enc
+++ b/src/tests/encore/basic/thisNotReassignable.enc
@@ -1,0 +1,7 @@
+class T
+  def init(): void {
+    this = null;
+  }
+
+class Main
+  def main() : void ()

--- a/src/tests/encore/basic/thisNotReassignable.fail
+++ b/src/tests/encore/basic/thisNotReassignable.fail
@@ -1,0 +1,1 @@
+Cannot rebind variable 'this'

--- a/src/types/Typechecker/Typechecker.hs
+++ b/src/types/Typechecker/Typechecker.hs
@@ -1015,6 +1015,8 @@ instance Checkable Expr where
     --  E |- name = rhs : void
     doTypecheck assign@(Assign {lhs = lhs@VarAccess{qname}, rhs}) =
         do eLhs <- typecheck lhs
+           when (isThisAccess lhs) $
+                  pushError eLhs ThisReassignmentError
            varIsMutable <- asks $ isMutableLocal qname
            varIsLocal <- asks $ isLocal qname
            unless varIsMutable $
@@ -1028,6 +1030,8 @@ instance Checkable Expr where
         do eLhs <- typecheck lhs
            unless (isLval eLhs) $
                   pushError eLhs NonAssignableLHSError
+           when (isThisAccess lhs) $
+                  pushError eLhs ThisReassignmentError
            mtd <- asks currentMethod
            unless (isNothing mtd || isConstructor (fromJust mtd)) $
                   assertNotValField eLhs


### PR DESCRIPTION
This commit fixes #640 and forbids re-binding the reference of the object (`this`) to another reference. I have provided a test case.

