### PR TITLE
fixes calling parametric functions inside parametric classes

### DIFF
--- a/src/tests/encore/basic/parametricClasses.enc
+++ b/src/tests/encore/basic/parametricClasses.enc
@@ -1,3 +1,5 @@
+def id<a>(x: a): a x
+
 class Cell<a>
   value : a
   def init(value : a) : void
@@ -21,6 +23,12 @@ class Pair<a, b>
 
   def getSnd() : b
     this.snd
+
+  -- tests type inference and explicit usage of parametric functions
+  def getFstViaId() : int {
+    id<int>(2);
+    id(3);
+  }
 
 class Main
   def main() : void{

--- a/src/types/Typechecker/Typechecker.hs
+++ b/src/types/Typechecker/Typechecker.hs
@@ -591,17 +591,17 @@ instance Checkable Expr where
 
       let argTypes = getArgTypes ty
           typeParams = getTypeParameters ty
+          uniquify = uniquifyTypeVars typeParams
       unless (isArrowType ty) $
         tcError $ NonFunctionTypeError ty
       unless (length args == length argTypes) $
         tcError $ WrongNumberOfFunctionArgumentsError
                     qname (length argTypes) (length args)
+      uniqueArgTypes <- mapM uniquify argTypes
       (eArgs, resultType, typeArgs) <-
           case typeArguments of
             Nothing -> do
-              let uniquify = uniquifyTypeVars typeParams
-              argTypes' <- mapM uniquify argTypes
-              (eArgs, bindings) <- matchArguments args argTypes'
+              (eArgs, bindings) <- matchArguments args uniqueArgTypes
               let resolve t = replaceTypeVars bindings <$> uniquify t
               resultType <- resolve (getResultType ty)
               typeArgs <- mapM resolve typeParams
@@ -619,7 +619,7 @@ instance Checkable Expr where
               let bindings = zip typeParams typeArgs'
               (eArgs, _) <-
                   local (bindTypes bindings) $
-                        matchArguments args argTypes
+                        matchArguments args uniqueArgTypes
               let resultType = replaceTypeVars bindings (getResultType ty)
               return (eArgs, resultType, typeArgs')
 


### PR DESCRIPTION
this PR fixes #650, calling parametric functions inside parametric classes.
the error was that the parametric class and the parametric function have the same type parameter name and the compiler was treating them as if they were the same. By using the `uniquifyTypeVar` function, we remove this ambiguity.

(this PR has been made together with @EliasC )