### PR TITLE
Fix type inference bug

### DIFF
--- a/src/tests/encore/basic/ifNothing.enc
+++ b/src/tests/encore/basic/ifNothing.enc
@@ -1,0 +1,7 @@
+class Main
+  def main() : void {
+    if true then
+       Nothing
+    else
+      Nothing
+  }

--- a/src/tests/encore/basic/ifNothing.fail
+++ b/src/tests/encore/basic/ifNothing.fail
@@ -1,0 +1,1 @@
+Cannot infer result type of if-statement

--- a/src/tests/encore/basic/maybeTypeInference.enc
+++ b/src/tests/encore/basic/maybeTypeInference.enc
@@ -1,4 +1,8 @@
 def foo() : (Maybe int, Maybe int) {
+  if false then
+    Nothing
+  else
+    Just (Just 42);
   if true then{
     if false then{
       (Just 42, Nothing : Maybe int)

--- a/src/types/Typechecker/Typechecker.hs
+++ b/src/types/Typechecker/Typechecker.hs
@@ -785,11 +785,14 @@ instance Checkable Expr where
                     Nothing -> do
                       ty1Sub <- ty1 `subtypeOf` ty2
                       ty2Sub <- ty2 `subtypeOf` ty1
-                      if ty1Sub || isVoidType ty2
-                      then return ty2
-                      else if ty2Sub || isVoidType ty1
-                           then return ty1
-                           else tcError $ IfBranchMismatchError ty1 ty2
+                      if ty1Sub || isVoidType ty2 then
+                          return ty2
+                      else if ty2Sub || isVoidType ty1 then
+                          return ty1
+                      else if knownType ty1 || knownType ty2 then
+                          tcError $ IfBranchMismatchError ty1 ty2
+                      else
+                          tcError IfInferenceError
 
 
     --  E |- arg : t'

--- a/src/types/Typechecker/Util.hs
+++ b/src/types/Typechecker/Util.hs
@@ -419,6 +419,7 @@ typeIsUnifiable ty
 isUnifiableWith ty types
     | isArrowType ty = return False
     | hasResultType ty &&
+      all hasResultType types &&
       all (hasSameKind ty) types =
           isUnifiableWith (getResultType ty) (map getResultType types)
     | isPassiveClassType ty = do


### PR DESCRIPTION
This commit fixes two issues:

* The following expression
  ```
  if true then
    Nothing
  else
    Nothing
  ```
  would result in an error message saying that `Maybe Bottom` does not
  match type `Maybe Bottom`. Now it instead says that in cannot infer
  the type of the if-statement.
* The following expression would crash the compiler:
  ```
  if true then
    Nothing
  else
    Just (Just 42)
  ```

The fix for both of these issues was adding extra checks for the bottom
type. One test has been updated and another test added.