### PR TITLE
Adding global abort() function

### DIFF
--- a/src/back/CodeGen/Expr.hs
+++ b/src/back/CodeGen/Expr.hs
@@ -335,6 +335,10 @@ instance Translatable A.Expr (State Ctx.Context (CCode Lval, CCode Stat)) where
       let exitCall = Call (Nam "exit") [narg]
       return (unit, Seq [Statement targ, Statement exitCall])
 
+  translate abort@(A.Abort {A.args = []}) = do
+      let abortCall = Call (Nam "abort") ([]::[CCode Lval]) 
+      return (unit, Statement abortCall)
+
   translate seq@(A.Seq {A.eseq}) = do
     ntes <- mapM translate eseq
     let (nes, tes) = unzip ntes

--- a/src/ir/AST/AST.hs
+++ b/src/ir/AST/AST.hs
@@ -658,6 +658,8 @@ data Expr = Skip {emeta :: Meta Expr}
                    args :: [Expr]}
           | Exit {emeta :: Meta Expr,
                   args :: [Expr]}
+          | Abort {emeta :: Meta Expr,
+                   args :: [Expr]}
           | StringLiteral {emeta :: Meta Expr,
                            stringLit :: String}
           | CharLiteral {emeta :: Meta Expr,

--- a/src/ir/AST/Desugarer.hs
+++ b/src/ir/AST/Desugarer.hs
@@ -103,6 +103,12 @@ desugar FunctionCall{emeta, qname = QName{qnlocal = Name "exit"}
                     ,args} =
     Exit emeta args
 
+-- Abort
+desugar FunctionCall{emeta, qname=QName{qnlocal=Name "abort"} , args=[msg]} =
+  Seq{emeta, eseq=[Print emeta Stderr [StringLiteral emeta "{}\n", msg]
+                  ,Print emeta Stderr [StringLiteral emeta $ Meta.showPos emeta ++ "\n"]
+                  ,Abort{emeta, args=[msg]}]}
+
 -- Print functions
 desugar FunctionCall{emeta, qname = QName{qnlocal = Name "println"}
                     ,args = []} =

--- a/src/ir/AST/PrettyPrinter.hs
+++ b/src/ir/AST/PrettyPrinter.hs
@@ -382,6 +382,7 @@ ppExpr NewWithInit {ty, args} =
 ppExpr New {ty} = "new" <+> ppType ty
 ppExpr Print {args} = "print" <> parens (commaSep (map ppExpr args))
 ppExpr Exit {args} = "exit" <> parens (commaSep (map ppExpr args))
+ppExpr Abort {args} = "abort" <> parens (commaSep (map ppExpr args))
 ppExpr StringLiteral {stringLit} = text $ show stringLit
 ppExpr CharLiteral {charLit} = text $ show charLit
 ppExpr UIntLiteral {intLit} = int intLit <> "u"

--- a/src/ir/AST/Util.hs
+++ b/src/ir/AST/Util.hs
@@ -118,6 +118,7 @@ getChildren NewWithInit {args} = args
 getChildren New {} = []
 getChildren Print {args} = args
 getChildren Exit {args} = args
+getChildren Abort {args} = args
 getChildren StringLiteral {} = []
 getChildren CharLiteral {} = []
 getChildren IntLiteral {} = []
@@ -132,6 +133,7 @@ getChildren Binop {loper, roper} = [loper, roper]
 -- replaced by the Exprs in @children@. The expected invariant is
 -- that @putChildren (getChildren e) e == e@ and @getChildren (putChildren l e) == l@
 putChildren :: [Expr] -> Expr -> Expr
+putChildren args e@Abort{} = e{args=args}
 putChildren [] e@Skip{} = e
 putChildren [] e@Break{} = e
 putChildren [] e@(FunctionAsValue {}) = e

--- a/src/tests/encore/basic/abort.enc
+++ b/src/tests/encore/basic/abort.enc
@@ -1,0 +1,11 @@
+class Main
+  def main() : unit
+    val v = Just(40)
+    match v with
+      case Just(42) => println(v)
+      case _  => abort("This is LA8PV transmitting on the shortwave band")
+    end
+    ()
+  end
+end
+  

--- a/src/tests/encore/basic/abort.err
+++ b/src/tests/encore/basic/abort.err
@@ -1,0 +1,2 @@
+This is LA8PV transmitting on the shortwave band
+"abort.enc" (line 6, column 18)

--- a/src/types/Typechecker/Typechecker.hs
+++ b/src/types/Typechecker/Typechecker.hs
@@ -1452,6 +1452,19 @@ instance Checkable Expr where
            matchArguments args expectedTypes
            return $ setType unitType exit {args = eArgs}
 
+    -- ------------------------
+    --  E |- abort() : _|_
+    doTypecheck abort@Abort{args} = do
+      sty <- resolveType stringObjectType
+      let expectedTypes = [sty]
+      unless (length args == length expectedTypes) $
+        tcError $ WrongNumberOfFunctionArgumentsError
+                  (topLevelQName (Name "abort"))
+                  (length expectedTypes) (length args)
+      eArgs <- mapM typecheck args
+      matchArguments args expectedTypes
+      return $ setType bottomType abort{args=([]::[Expr])}
+
     doTypecheck stringLit@(StringLiteral {}) = return $ setType stringType stringLit
 
     doTypecheck charLit@(CharLiteral {}) = return $ setType charType charLit


### PR DESCRIPTION
This PR adds support for a global abort() function

* abort() :: String -> _|_  (bottom type)
* Abort is implemented at C-level using abort() in stdlib.h
* Abort will print its mandatory string argument to STDERR
* An abort test is added

**NB** This needs the perror PR to work as it prints to STDERR

Please squash commits on merge. 