### PR TITLE
reduce size of test `reduce.enc`

### DIFF
--- a/src/tests/encore/par/reduce.enc
+++ b/src/tests/encore/par/reduce.enc
@@ -41,8 +41,8 @@ end
 class Main
   def main() : void
     let
-      f = reduce(sum, 0, millionItems(1000000))
-      f2 = reduce(sum, 0, millionFutures(1000000))
+      f = reduce(sum, 0, millionItems(1000))
+      f2 = reduce(sum, 0, millionFutures(1000))
       v = get(f)
       v2 = get(f2)
     in

--- a/src/tests/encore/par/reduce.out
+++ b/src/tests/encore/par/reduce.out
@@ -1,2 +1,2 @@
-Result million values: 499999500000
-Result million futures: 499999500000
+Result million values: 499500
+Result million futures: 499500


### PR DESCRIPTION
Reduces the size of the number of elements computed in the `reduce.enc` test.
this PR should fix #703 
