### PR TITLE
Remove support for matching methods

### DIFF
--- a/src/ir/AST/AST.hs
+++ b/src/ir/AST/AST.hs
@@ -141,17 +141,7 @@ data FunctionHeader =
         hname       :: Name,
         htype       :: Type,
         hparams     :: [ParamDecl]
-    }
-    | MatchingHeader {
-        hmodifiers   :: [Modifier],
-        kind        :: HeaderKind,
-        htypeparams :: [Type],
-        hname       :: Name,
-        htype       :: Type,
-        hparamtypes :: [Type],
-        hpatterns   :: [Expr],
-        hguard      :: Expr
-    }deriving(Eq, Show)
+    } deriving(Eq, Show)
 
 
 setHeaderType ty h = h{htype = ty}
@@ -170,8 +160,6 @@ isMatchMethod = isMatchMethodHeader . mheader
 
 isStreamMethodHeader h = kind h == Streaming
 
--- MatchingFunction instances should be replaced by regular
--- functions after desugaring
 data Function =
     Function {
       funmeta   :: Meta Function,
@@ -179,13 +167,6 @@ data Function =
       funbody   :: Expr,
       funlocals :: [Function],
       funsource :: FilePath
-    }
-  | MatchingFunction {
-      funmeta         :: Meta Function,
-      matchfunheaders :: [FunctionHeader],
-      matchfunbodies  :: [Expr],
-      funlocals       :: [Function],
-      funsource       :: FilePath
     } deriving (Show)
 
 functionName = hname . funheader
@@ -204,12 +185,8 @@ instance HasMeta Function where
   setMeta f m = f{funmeta = m}
   setType ty f@(Function {funmeta}) =
       f{funmeta = AST.Meta.setType ty funmeta}
-  setType ty f@(MatchingFunction {funmeta}) =
-      f{funmeta = AST.Meta.setType ty funmeta}
   showWithKind Function{funheader} =
       "function '" ++ show (hname funheader) ++ "'"
-  showWithKind MatchingFunction{matchfunheaders} =
-      "function '" ++ show (hname $ head matchfunheaders) ++ "'"
 
 data ClassDecl = Class {
   cmeta       :: Meta ClassDecl,
@@ -450,12 +427,7 @@ data MethodDecl =
       mmeta   :: Meta MethodDecl,
       mheader :: FunctionHeader,
       mlocals :: [Function],
-      mbody   :: Expr}
-  | MatchingMethod {
-      mmeta    :: Meta MethodDecl,
-      mheaders :: [FunctionHeader],
-      mlocals  :: [Function],
-      mbodies  :: [Expr]
+      mbody   :: Expr
     } deriving (Show)
 
 methodName = hname . mheader

--- a/src/ir/AST/PrettyPrinter.hs
+++ b/src/ir/AST/PrettyPrinter.hs
@@ -136,8 +136,6 @@ ppFunctionHelper funheader funbody funlocals =
 ppFunction :: Function -> Doc
 ppFunction Function {funheader, funbody, funlocals} =
   ppFunctionHelper funheader funbody funlocals
-ppFunction MatchingFunction{} =
-  error "Encore currently does not support matching functions"
 
 ppTraitDecl :: TraitDecl -> Doc
 ppTraitDecl Trait {tname, treqs, tmethods} =

--- a/src/ir/AST/Util.hs
+++ b/src/ir/AST/Util.hs
@@ -301,11 +301,6 @@ extendAccumProgram f acc0 p@Program{functions, traits, classes, imports} =
         where
           (acc', funbody') = extendAccum f acc funbody
 
-      extendAccumFunction f acc fun@(MatchingFunction{matchfunbodies}) =
-        (acc', fun{matchfunbodies = funbodies'})
-        where
-          (acc', funbodies') = List.mapAccumL (extendAccum f) acc matchfunbodies
-
       (acc2, traits') = List.mapAccumL (extendAccumTrait f) acc1 traits
       extendAccumTrait f acc trt@(Trait{tmethods}) =
         (acc', trt{tmethods = tmethods'})
@@ -322,11 +317,6 @@ extendAccumProgram f acc0 p@Program{functions, traits, classes, imports} =
         (acc', mtd{mbody = mbody'})
         where
           (acc', mbody') = extendAccum f acc mbody
-
-      extendAccumMethod f acc mtd@(MatchingMethod{mbodies}) =
-        (acc', mtd{mbodies = mbodies'})
-        where
-          (acc', mbodies') = List.mapAccumL (extendAccum f) acc mbodies
 
 -- | @filter cond e@ returns a list of all sub expressions @e'@ of
 -- @e@ for which @cond e'@ returns @True@
@@ -348,9 +338,6 @@ extractTypes (Program{functions, traits, classes}) =
       extractFunctionTypes Function{funheader, funbody} =
           extractHeaderTypes funheader ++
           extractExprTypes funbody
-      extractFunctionTypes MatchingFunction{matchfunheaders, matchfunbodies} =
-          List.foldr (\h acc -> (extractHeaderTypes h) ++ acc) [] matchfunheaders ++
-          List.foldr (\b acc -> (extractExprTypes b) ++ acc) [] matchfunbodies
 
       extractTraitTypes :: TraitDecl -> [Type]
       extractTraitTypes Trait {tname, treqs, tmethods} =
@@ -374,9 +361,6 @@ extractTypes (Program{functions, traits, classes}) =
       extractMethodTypes Method{mheader, mbody} =
           extractHeaderTypes mheader ++
           extractExprTypes mbody
-      extractMethodTypes MatchingMethod{mheaders, mbodies} =
-        List.foldr (\h -> (extractHeaderTypes h ++)) [] mheaders ++
-        List.foldr (\b -> (extractExprTypes b ++)) [] mbodies
 
       extractParamTypes :: ParamDecl -> [Type]
       extractParamTypes Param {ptype} = typeComponents ptype

--- a/src/parser/Parser/OldParser.hs
+++ b/src/parser/Parser/OldParser.hs
@@ -364,41 +364,22 @@ guard = do
   reserved "when"
   expression
 
-matchingHeader = do
-   hname <- Name <$> identifier
-   htypeparams <- optionalTypeParameters
-   args <- parens (commaSep patternParamDecl)
-   colon
-   htype <- typ
-   posGuard <- getPosition
-   hguard <- option (BTrue (meta posGuard)) guard
-   let (hpatterns, hparamtypes) = unzip  args
-   return MatchingHeader{hmodifiers = []
-                        ,kind = NonStreaming
-                        ,htypeparams
-                        ,hname
-                        ,hpatterns
-                        ,hparamtypes
-                        ,htype
-                        ,hguard
-                        }
-
+matchingHeader :: Parser FunctionHeader
+matchingHeader = fail "Matching functions and methods are no longer supported"
 matchingStreamHeader :: Parser FunctionHeader
-matchingStreamHeader = do
-  header <- matchingHeader
-  return header{kind = Streaming}
+matchingStreamHeader = fail "Matching functions and methods are no longer supported"
 
 localFunctions :: Parser [Function]
 localFunctions =
     option [] $ do
       reserved "where"
-      locals <- some (try regularFunction <|> matchingFunction)
+      locals <- some (regularFunction <|> matchingFunction)
       reserved "end"
       return locals
 
 function :: Parser Function
 function = do
-  fun <- try regularFunction <|> matchingFunction
+  fun <- regularFunction <|> matchingFunction
   funlocals <- localFunctions
   return fun{funlocals}
 
@@ -414,23 +395,7 @@ regularFunction = do
                  ,funsource = ""
                  }
 
-matchingFunction = do
-  funmeta <- meta <$> getPosition
-  reserved "def"
-  clauses <- functionClause `sepBy1` reservedOp "|"
-  let matchfunheaders = map fst clauses
-      matchfunbodies = map snd clauses
-  return MatchingFunction{funmeta
-                         ,matchfunheaders
-                         ,matchfunbodies
-                         ,funlocals = []
-                         ,funsource = ""
-                         }
-  where
-    functionClause = do
-      funheader <- matchingHeader
-      funbody <- expression
-      return (funheader, funbody)
+matchingFunction = fail "Matching functions and methods are no longer supported"
 
 traitDecl :: Parser TraitDecl
 traitDecl = do
@@ -558,7 +523,7 @@ patternParamDecl = do
 
 methodDecl :: Parser MethodDecl
 methodDecl = do
-  mtd <- try regularMethod <|> matchingMethod
+  mtd <- regularMethod <|> matchingMethod
   mlocals <- localFunctions
   return mtd{mlocals}
   where
@@ -575,26 +540,7 @@ methodDecl = do
                    ,mbody
                    ,mlocals = []
                    }
-    matchingMethod = do
-      mmeta <- meta <$> getPosition
-      clauses <- do reserved "def"
-                    modifiers <- option [] $ many modifiersDecl
-                    map (first (setHeaderModifier modifiers)) <$>
-                      methodClause matchingHeader `sepBy1` reservedOp "|"
-             <|> do reserved "stream"
-                    methodClause matchingStreamHeader `sepBy1` reservedOp "|"
-      let (mheaders, mbodies) = unzip clauses
-
-      return MatchingMethod{mmeta
-                           ,mheaders
-                           ,mbodies
-                           ,mlocals = []
-                           }
-      where
-        methodClause headerParser= do
-          mheader <- headerParser
-          mbody <- expression
-          return (mheader, mbody)
+    matchingMethod = fail "Matching functions and methods are no longer supported"
 
 modifiersDecl :: Parser Modifier
 modifiersDecl = reserved "private" >> return ModPrivate

--- a/src/tests/encore/match/match.enc
+++ b/src/tests/encore/match/match.enc
@@ -1,33 +1,3 @@
--- def fac(0 : int) : int {
---   1
--- } | fac(n : int) : int {
---   n * fac(n-1)
--- }
-
-
-
--- def testGuardInFunctionHead(x : String) : void when false {
---   print "error"
--- } | testGuardInFunctionHead(x : String) : void when true {
---   print x
--- }
-
--- def expectEven(Odd(a) : IntContainer) : void {
---   print "error"
--- } | expectEven(Even(b) : IntContainer) : void {
---   print "correct"
--- }
-
--- def printMaybe((Just (x)) : Maybe int) : void {
---   println("Just {}", x)
--- } | printMaybe(Nothing : Maybe int) : void {
---   print "Nothing"
--- }
-
--- fun testHigherOrderExprInMatchingFunctionHead() : void
---   printMaybe(Just (3))
--- end
-
 passive class IntContainer
   val elem : int
 
@@ -81,31 +51,6 @@ passive class B :  Letter
   end
 end
 
-passive class C
---  def foo(0 : int, "foo" : String) : void
---    print "yes"
---    | foo(x : int, bar : String) :  void
---    print "no"
---  }
-end
-
-class NumberStreamer
---  stream multiples(1 : int, limit : int) : int {
---    var i = 0;
---    while i < limit {
---      yield i;
---      i = i + 1;
---    }
---  }
---  | multiples(n : int, limit : int) : int {
---    var i = 0;
---    while i < limit {
---      yield i;
---      i = i + n;
---    }
---  }
-end
-
 passive class Foo
   def AlwaysMatchingExtractor() : Maybe[void]
     Just(())
@@ -135,28 +80,6 @@ class Main
     end
   end
 
---  def matchingOnMethodHead() : void
---    (new C()).foo(0, "foo") -- Matches first clause
---    (new C()).foo(0, "bar")  -- Matches last clause
---  end
-
---  def matchingOnFunctionHead() : void
---    println(fac(5))
---  end
-
---  def matchingOnStreamHead() : void
---    val x = new NumberStreamer
---    var evens = x.multiples(2, 10)
---    while (not eos evens) do
---      println(get(evens))
---      evens = getNext(evens)
---    end
---  end
-
---  def objectPatternsInFunctionHead() : void
---    expectEven(new IntContainer(4))
---  end
-
   -- Issue #427, this should compile!
   def variablePatternAgainstLambda() : void
     let f = fun (x : int) => x in
@@ -179,12 +102,6 @@ class Main
     this.objectPatternTestWithFailingGuard()
     this.valueVariableTuplePatternsTestWithFailingGuard()
     this.evaluatesToTraitTest()
---    this.matchingOnMethodHead()
---    this.matchingOnFunctionHead()
---    this.objectPatternsInFunctionHead()
---    this.matchingOnStreamHead()
---    testGuardInFunctionHead("correct")
---    testHigherOrderExprInMatchingFunctionHead()
     this.variablePatternAgainstLambda()
     this.testEmptyExtractors()
   end


### PR DESCRIPTION
This commit removes the remnants of matching functions and
methods from the compiler, i.e. having

```
fun fact(0) : int
  1
  | fact(n : int) : int
  n * fact(n - 1)
end
```
desugar into
```
fun fact(n : int) : int
  match n with
    case 0 => 1
    case n => n * fact(n - 1)
  end
end
```

This has not been implemented with the new syntax, and while it is
a neat feature, I think that we will be doing ourselves a favour
by removing this complexity from the compiler.