### PR TITLE
refactor codegen for msg send

### DIFF
--- a/src/back/CodeGen/Expr.hs
+++ b/src/back/CodeGen/Expr.hs
@@ -614,7 +614,6 @@ instance Translatable A.Expr (State Ctx.Context (CCode Lval, CCode Stat)) where
       targetTy = A.getType target
       isActive = Ty.isActiveClassType targetTy
       isStream = Ty.isStreamType $ A.getType call
-      isFuture = Ty.isFutureType $ A.getType call
 
       delegateUseM msgSend sym = do
         (ntarget, ttarget) <- translate target


### PR DESCRIPTION
refactor to a single function the code gen for message sends. there was quite a bit of duplication and this commit unifies the code gen for message sends considering future elision