### PR TITLE
This PR adds a warning for expressions used as statements

### DIFF
--- a/src/ir/AST/Util.hs
+++ b/src/ir/AST/Util.hs
@@ -450,7 +450,7 @@ mark asParent s@IfThenElse{cond, thn, els} =
 mark asParent s@Async{body} = asParent s{body=mark asParent body}
 mark asParent s@Assign {lhs, rhs} = asStat s{lhs=markAsStat lhs, rhs=markAsExpr rhs}
 mark asParent s@Print {args} = asStat s{args=map markAsExpr args}
-mark asParent s@MaybeValue{mdt=d@JustData{e}} = asParent s{mdt=d{e=mark asParent e}}
+mark asParent s@MaybeValue{mdt=d@JustData{e}} = asParent s{mdt=d{e=mark markAsExpr e}}
 mark asParent s@Let{body, decls} =
   asParent s{body=mark asParent body, decls=map markDecl decls}
   where

--- a/src/tests/encore/basic/statements.enc
+++ b/src/tests/encore/basic/statements.enc
@@ -1,0 +1,12 @@
+class ThisClassDeliberatelyNotCalledMain
+  def main() : unit
+    1
+    1.0 + 2.0
+    true || false 
+    Just(new ThisClassDeliberatelyNotCalledMain())
+    Nothing
+    [1]
+    (23, new String("Hello"))
+  end
+end
+  

--- a/src/tests/encore/basic/statements.fail
+++ b/src/tests/encore/basic/statements.fail
@@ -1,0 +1,9 @@
+Result of '(23, new String("Hello"))' is discarded
+Result of '[1]' is discarded
+Result of 'Nothing' is discarded
+Result of 'Just(new ThisClassDeliberatelyNotCalledMain())' is discarded
+Result of 'true || false' is discarded
+Result of '1.0 + 2.0' is discarded
+Result of '1' is discarded
+Couldn't find active class 'Main'
+

--- a/src/types/Typechecker/TypeError.hs
+++ b/src/types/Typechecker/TypeError.hs
@@ -635,6 +635,7 @@ data Warning = StringDeprecatedWarning
              | StringIdentityWarning
              | PolymorphicIdentityWarning
              | ShadowedMethodWarning FieldDecl
+             | ExpressionResultIgnoredWarning Expr
 instance Show Warning where
     show StringDeprecatedWarning =
         "Type 'string' is deprecated. Use 'String' instead."
@@ -643,6 +644,8 @@ instance Show Warning where
     show PolymorphicIdentityWarning =
         "Comparing polymorphic values is unstable. \n" ++
         "Later versions of Encore will require type constraints for this to work"
+    show (ExpressionResultIgnoredWarning expr) = 
+        "Result of '" ++ (show $ ppSugared expr) ++ "' is discarded"
     show (ShadowedMethodWarning Field{fname, ftype}) =
         printf ("Field '%s' holds %s and could be confused with " ++
                 "the method of the same name")


### PR DESCRIPTION
This PR adds a warning to the compiler when expressions
that should be side-effect free are used only for side effects.
For example, the following program omits 6 warnings:

```
class Foo
  def main() : unit
    1              <-- "The result of '1' is discarded'
    1.0 + 2.0      <-- "The result of '1.0 + 2.0' is discarded'
    true           <-- etc.
    Just(new Foo())
    (2, 34 + 34)
    [1]
  end
end
```

Closes #639

There has been some cleaning up of Haskell code as part of this work, 
mostly fixing indentation and aligning styles, which is why the footprint
seems larger than it really is. 