### PR TITLE
Fix bug where async this calls do not return future type

### DIFF
--- a/src/tests/encore/basic/asyncThisCall.enc
+++ b/src/tests/encore/basic/asyncThisCall.enc
@@ -1,0 +1,23 @@
+passive class Cell
+  var value : int
+  def init(v:int) : unit
+    this.value = v
+  end
+end
+
+class Foo
+  def foo(i:int) : Cell
+    new Cell(i)
+  end
+  def bar() : unit
+    val f = new Foo()
+    val g = this ! foo(42)
+    g.value = 42 --- this should not compile
+  end
+end
+  
+class Main
+  def main() : unit
+    new Foo() ! foo(42)
+  end
+end

--- a/src/tests/encore/basic/asyncThisCall.fail
+++ b/src/tests/encore/basic/asyncThisCall.fail
@@ -1,0 +1,1 @@
+Cannot read field of expression 'g' of future type Fut\\[Cell\\]


### PR DESCRIPTION
Currently, when this is active, this ! foo() will not have a
future type, leading to badness. This PR fixes that so that
when this has the type Foo with the following partial definition:

class Foo
  def foo() : int
    ...

this ! foo() has type Fut[int] and this . foo() has type int.
