### PR TITLE
Implicitly import the Task library 

### DIFF
--- a/modules/standard/Task.enc
+++ b/modules/standard/Task.enc
@@ -126,11 +126,11 @@ fun Synchroniser[t](f : Fut[t]) : Synchroniser[t]
 end
 
 class Synchroniser[t]
-  var result : [t]
+  var value : [t]
   var countDown : int
   var callback : t -> unit
   def init(ar : [Fut[t]]) : unit
-    this.result = new [t](|ar|)
+    this.value = new [t](|ar|)
     this.countDown = |ar|
     var i = 0
     for f <- ar do
@@ -142,7 +142,7 @@ class Synchroniser[t]
   end
   def fulfil(pos : int, r : t) : unit
     this.countDown = this.countDown - 1
-    (this.result)(pos) = r
+    (this.value)(pos) = r
   end
   def register(closure : t -> unit) : unit
     this.callback = closure
@@ -151,7 +151,7 @@ class Synchroniser[t]
     while this.countDown > 0 do
       this.suspend()
     end
-    this.result
+    this.value
   end
 end
 #+END_SRC

--- a/src/front/ModuleExpander.hs
+++ b/src/front/ModuleExpander.hs
@@ -45,7 +45,7 @@ shortenPrelude preludePaths source =
     then basename source
     else source
 
-stdLib source = [lib "String", lib "Std"]
+stdLib source = [lib "String", lib "Std", lib "Task"]
     where
       lib s = Import{imeta = meta $ initialPos source
                     ,itarget = explicitNamespace [Name s]


### PR DESCRIPTION
This PR imports always the Task library in a similar fashion as how the `String` and `Std` libraries are imported. This fixes the issue of using the `async` keyword without importing the `Task` library, which used to result in: `I don't know what `spawn` means` (or similar). I have also changed the name of a variable to avoid the warning of `the name of a variable of array type and a method have the same name`
