### PR TITLE
Fix tracing of trait types

### DIFF
--- a/src/runtime/encore/encore.h
+++ b/src/runtime/encore/encore.h
@@ -187,7 +187,7 @@ static inline void encore_trace_capability(
     void *p)
 {
   if (p) {
-    ((capability_t*) p)->_enc__self_type->trace(ctx, p);
+    encore_trace_object(ctx, p, ((capability_t*) p)->_enc__self_type->trace);
   }
 }
 

--- a/src/tests/encore/traits/traitTracing.enc
+++ b/src/tests/encore/traits/traitTracing.enc
@@ -1,0 +1,130 @@
+-- Based on Alberts implementation of the Concurrent Linked List
+-- Savina benchmark
+
+import Random
+
+trait Ord
+  require def compare(o:Ord) : int
+end
+
+passive class Integer : Ord(i)
+  val i:int
+
+  def init(i:int) : unit
+    this.i = i
+  end
+
+  def compare(other:Ord) : int
+    val y = EMBED (Integer) (void*)#{other}; END
+    this.i - y.i
+  end
+end
+
+passive class Node : Id
+  val elem : Ord
+  var next : Node
+
+  def init(i:int) : unit
+    this.elem = new Integer(i)
+  end
+end
+
+passive class SortedList
+  var head : Node
+
+  def add(i:int) : unit
+    if this.head == (null : Node) then
+      this.head = new Node(i)
+    else
+      val n = new Node(i)
+      if n.elem.compare(this.head.elem) <= 0 then
+        n.next = this.head
+        this.head = n
+      else
+        var before = this.head
+        var after = this.head.next
+        while after != (null : Node) do
+          if n.elem.compare(after.elem) <= 0 then
+            break
+          end
+          before = after
+          after = after.next
+        end
+        n.next = before.next
+        before.next = n
+      end
+    end
+  end
+
+  def contains(i:int) : bool
+    val n = new Node(i)
+    var cur = this.head
+    while cur != (null : Node) do
+      if cur.elem.compare(n.elem) == 0 then
+        return true
+      end
+      cur = cur.next
+    end
+    false
+  end
+end
+
+class ConcurrentSortedList
+  var list:SortedList
+
+  def init() : unit
+    this.list = new SortedList
+  end
+
+  def add(x:int) : unit
+    this.list.add(x)
+  end
+
+  def contains(x:int) : bool
+    this.list.contains(x)
+  end
+end
+
+class Worker
+  var db:ConcurrentSortedList
+  var write_percent:int
+  var size_percent:int
+  var r:Random
+
+  def init(n_msg:int, write_percent:int, size_percent:int) : unit
+    this.db = new ConcurrentSortedList
+    this.write_percent = write_percent
+    this.size_percent = size_percent
+    this.r = new Random(0)
+    this!loop(n_msg)
+  end
+
+  def loop(n:int) : unit
+    if n == 0 then
+      ()
+    else
+      var x = this.r.random(100)
+      if x <= this.size_percent + this.write_percent then
+        this.db!add(this.r.random(1000*1000*1000))
+        ()
+      else
+        this.db!contains(this.r.random(1000*1000*1000))
+        ()
+      end
+      this!loop(n-1)
+    end
+  end
+end
+
+class Main
+  def main(args: [String]) : unit
+    var n_workers = 1
+    var msg_per_worker = 10000
+    var write_percent = 10
+    var size_percent = 1
+    for i <- [0 .. n_workers-1] do
+      new Worker(msg_per_worker, write_percent, size_percent)
+    end
+    println("I compile and run!")
+  end
+end

--- a/src/tests/encore/traits/traitTracing.out
+++ b/src/tests/encore/traits/traitTracing.out
@@ -1,0 +1,1 @@
+I compile and run!


### PR DESCRIPTION
We were calling the trace function directly rather than calling
`encore_trace_object` with the trace function supplied (which is
the correct usage). The added test is based on @albertnetymk's
implementation of the Concurrent Linked List Savina benchmark,
and segfaults without this fix.