### PR TITLE
add 4.fjthrput benchmark

### DIFF
--- a/src/tests/stress/savina/4.fjthrput/ThroughputActor.enc
+++ b/src/tests/stress/savina/4.fjthrput/ThroughputActor.enc
@@ -1,0 +1,18 @@
+module ThroughputActor
+
+import ThroughputConfig
+
+active class ThroughputActor
+  var messagesProcessed: uint
+  val totalMessages : uint
+
+  def init(totalMessages: int): unit
+    this.messagesProcessed = 0
+    this.totalMessages = totalMessages
+  end
+
+  def process(config: ThroughputConfig): unit
+    this.messagesProcessed += 1
+    config.performComputation(37.2)
+  end
+end

--- a/src/tests/stress/savina/4.fjthrput/ThroughputConfig.enc
+++ b/src/tests/stress/savina/4.fjthrput/ThroughputConfig.enc
@@ -1,0 +1,25 @@
+module ThroughputConfig
+
+read class ThroughputConfig
+  val N: int
+  val A: int
+  val C: int
+  val usePriorities: bool
+
+  def init(N: int, A: int, C: int, priority: bool): unit
+    this.N = N
+    this.A = A
+    this.C = C
+    this.usePriorities = priority
+  end
+
+  def performComputation(theta: real): unit
+    val sint = EMBED (real)
+                 sin(#{theta});
+               END
+    val res = sint * sint
+    if (res <= 0) then
+      abort("IllegalStateException: Benchmark exited with unrealistic res value")
+    end
+  end
+end

--- a/src/tests/stress/savina/4.fjthrput/ThroughputEncore.enc
+++ b/src/tests/stress/savina/4.fjthrput/ThroughputEncore.enc
@@ -1,0 +1,58 @@
+import ThroughputConfig
+import ThroughputActor
+
+fun getFromMaybe(x: Maybe[int]): int
+  match x with
+    case Just(i) => i
+    case Nothing => abort("Error: no value in maybe type")
+  end
+end
+
+fun bool_from_int(x: int): bool
+  if x == 0 then
+    return false
+  else
+    return true
+  end
+end
+
+active class Main
+  def parseArgs(args: [String]): ThroughputConfig
+    if |args| > 1 then
+      return new ThroughputConfig(getFromMaybe(args(1).to_int()),
+                                  getFromMaybe(args(2).to_int()),
+                                  getFromMaybe(args(3).to_int()),
+                                  bool_from_int(getFromMaybe(args(4).to_int())))
+    else
+      return new ThroughputConfig(10000, 60, 1, true)
+    end
+  end
+
+  def runIteration(config: ThroughputConfig): unit
+    val actors = tabulate(config)
+    var m = 0
+    while m < config.N do
+      forallActor(actors, config)
+      m += 1
+    end
+    println("Success") -- Encore specific
+  where
+    fun forallActor(actors: [ThroughputActor], config: ThroughputConfig): unit
+      for i <- [0 .. |actors|-1] do
+        (actors(i))!process(config)
+      end
+    end
+    fun tabulate(config: ThroughputConfig): [ThroughputActor]
+      val arr = new [ThroughputActor](config.A)
+      for i <- [ 0 .. |arr|-1 ] do
+         arr(i) = new ThroughputActor(config.N)
+      end
+      arr
+    end
+  end
+
+  def main(args: [String]): unit
+    val config = this.parseArgs(args)
+    this.runIteration(config)
+  end
+end

--- a/src/tests/stress/savina/4.fjthrput/ThroughputEncore.out
+++ b/src/tests/stress/savina/4.fjthrput/ThroughputEncore.out
@@ -1,0 +1,1 @@
+Success


### PR DESCRIPTION
Add savina benchmark `4. Fork Join Throughput`. This benchmark has been implemented on top of Kappa and the tests will fail until Kappa is merged
