### PR TITLE
Remove unused ParT-nodes

### DIFF
--- a/src/back/CodeGen/Expr.hs
+++ b/src/back/CodeGen/Expr.hs
@@ -106,11 +106,8 @@ getRuntimeType :: A.Expr -> CCode Expr
 getRuntimeType = runtimeType . Ty.getResultType . A.getType
 
 newParty :: A.Expr -> CCode Name
-newParty (A.Liftv {}) = partyNewParV
-newParty (A.Liftf {}) = partyNewParF
 newParty (A.PartyPar {}) = partyNewParP
-newParty _ = error $ "ERROR in 'Expr.hs': node is different from 'Liftv', " ++
-                     "'Liftf' or 'PartyPar'"
+newParty _ = error "Expr.hs: node is not 'PartyPar'"
 
 translateDecl (vars, expr) = do
   (ne, te) <- translate expr
@@ -185,39 +182,6 @@ instance Translatable A.Expr (State Ctx.Context (CCode Lval, CCode Stat)) where
           StatAsExpr (if Ty.isTypeVar ty
                       then fromEncoreArgT (Ptr void) (AsExpr n)
                       else n) t
-
-  translate l@(A.Liftf {A.val}) = do
-    (nval, tval) <- translate val
-    let runtimeT = (runtimeType . A.getType) val
-    (nliftf, tliftf) <- namedTmpVar "par" (A.getType l) $
-                        Call (newParty l) [AsExpr encoreCtxVar, AsExpr nval, runtimeT]
-    return (nliftf, Seq [tval, tliftf])
-
-  translate l@(A.Liftv {A.val}) = do
-    (nval, tval) <- translate val
-    let runtimeT = (runtimeType . A.getType) val
-    (nliftv, tliftv) <- namedTmpVar "par" (A.getType l) $
-                        Call (newParty l) [AsExpr encoreCtxVar,
-                                           asEncoreArgT (translate $ A.getType val) (AsExpr nval), runtimeT]
-    return (nliftv, Seq [tval, tliftv])
-
-  translate p@(A.PartyJoin {A.val}) = do
-    (nexpr, texpr) <- translate val
-    let typ = A.getType p
-    (nJoin, tJoin) <- namedTmpVar "par" typ $ Call partyJoin [encoreCtxVar, nexpr]
-    return (nJoin, Seq [texpr, tJoin])
-
-  translate p@(A.PartyExtract {A.val}) = do
-    (nval, tval) <- translate val
-    let runtimeT = (runtimeType . Ty.getResultType . A.getType) p
-    (nExtract, tExtract) <- namedTmpVar "arr" (A.getType p) $
-                            Call partyExtract [AsExpr encoreCtxVar, AsExpr nval, runtimeT]
-    return (nExtract, Seq [tval, tExtract])
-
-  translate p@(A.PartyEach {A.val}) = do
-    (nval, tval) <- translate val
-    (nEach, tEach) <- namedTmpVar "par" (A.getType p) $ Call partyEach [encoreCtxVar, nval]
-    return (nEach, Seq [tval, tEach])
 
   translate p@(A.PartyPar {A.parl, A.parr}) = do
     (nleft, tleft) <- translate parl

--- a/src/ir/AST/AST.hs
+++ b/src/ir/AST/AST.hs
@@ -572,19 +572,6 @@ data Expr = Skip {emeta :: Meta Expr}
                      eparams :: [ParamDecl],
                      mty :: Maybe Type,
                      body :: Expr}
-          -- TODO: the AST nodes below can be removed as soon as
-          -- OldParser.hs gets removed
-          | Liftf {emeta :: Meta Expr,
-                   val :: Expr}
-          | Liftv {emeta :: Meta Expr,
-                   val :: Expr}
-          | PartyJoin {emeta :: Meta Expr,
-                       val :: Expr}
-          | PartyExtract {emeta :: Meta Expr,
-                          val :: Expr}
-          | PartyEach {emeta :: Meta Expr,
-                       val :: Expr}
-          -- END TODO
           | PartySeq {emeta :: Meta Expr,
                       par :: Expr,
                       seqfunc :: Expr}

--- a/src/ir/AST/PrettyPrinter.hs
+++ b/src/ir/AST/PrettyPrinter.hs
@@ -273,11 +273,6 @@ ppExpr MessageSend {target, name, args, typeArguments} =
     maybeParens target <> "!" <> ppName name <>
       withTypeArguments typeArguments <>
       parens (commaSep (map ppExpr args))
-ppExpr Liftf {val} = "liftf" <> parens (ppExpr val)
-ppExpr Liftv {val} = "liftv" <> parens (ppExpr val)
-ppExpr PartyJoin {val} = "join" <> parens (ppExpr val)
-ppExpr PartyExtract {val} = "extract" <> parens(ppExpr val)
-ppExpr PartyEach {val} = "each" <> parens(ppExpr val)
 ppExpr PartySeq {par, seqfunc} = ppExpr par <+> ">>" <+> parens (ppExpr seqfunc)
 ppExpr PartyPar {parl, parr} = ppExpr parl <+> "|||" <+> ppExpr parr
 ppExpr PartyReduce {seqfun, pinit, par} = "reduce" <>

--- a/src/ir/AST/Util.hs
+++ b/src/ir/AST/Util.hs
@@ -72,11 +72,6 @@ getChildren MessageSend {target, args} = target : args
 getChildren ExtractorPattern {arg} = [arg]
 getChildren FunctionCall {args} = args
 getChildren FunctionAsValue {} = []
-getChildren Liftf {val} = [val]
-getChildren Liftv {val} = [val]
-getChildren PartyJoin {val} = [val]
-getChildren PartyExtract {val} = [val]
-getChildren PartyEach {val} = [val]
 getChildren PartySeq {par, seqfunc} = [par, seqfunc]
 getChildren PartyPar {parl, parr} = [parl, parr]
 getChildren PartyReduce {seqfun, pinit, par} = [pinit, par, seqfun]
@@ -155,11 +150,6 @@ putChildren (target : args) e@(MethodCall {}) = e{target = target, args = args}
 putChildren (target : args) e@(MessageSend {}) = e{target = target, args = args}
 putChildren [arg] e@(ExtractorPattern {}) = e{arg = arg}
 putChildren args e@(FunctionCall {}) = e{args = args}
-putChildren [val] e@(Liftf {}) = e{val}
-putChildren [val] e@(Liftv {}) = e{val}
-putChildren [val] e@(PartyJoin {}) = e{val}
-putChildren [val] e@(PartyExtract {}) = e{val}
-putChildren [val] e@(PartyEach {}) = e{val}
 putChildren [par, seqfunc] e@(PartySeq {}) = e{par=par, seqfunc=seqfunc}
 putChildren [l, r] e@(PartyPar {}) = e{parl=l, parr=r}
 putChildren [pinit, par, seqfun] e@(PartyReduce {}) = e{par=par, seqfun=seqfun, pinit=pinit}
@@ -236,11 +226,6 @@ putChildren _ e@(MethodCall {}) = error "'putChildren l MethodCall' expects l to
 putChildren _ e@(MessageSend {}) = error "'putChildren l MessageSend' expects l to have at least 1 element"
 putChildren _ e@(ExtractorPattern {}) = error "'putChildren l ExtractorPattern' expects l to have 1 element"
 putChildren _ e@(FunctionAsValue {}) = error "'putChildren l FunctionAsValue' expects l to have 0 elements"
-putChildren _ e@(Liftf {}) = error "'putChildren l Liftf' expects l to have 1 element"
-putChildren _ e@(Liftv {}) = error "'putChildren l Liftv' expects l to have 1 element"
-putChildren _ e@(PartyJoin {}) = error "'putChildren l PartyJoin' expects l to have 1 element"
-putChildren _ e@(PartyExtract {}) = error "'putChildren l PartyExtract' expects l to have 1 element"
-putChildren _ e@(PartyEach {}) = error "'putChildren l PartyEach' expects l to have 1 element"
 putChildren _ e@(PartySeq {}) = error "'putChildren l PartySeq' expects l to have 2 elements"
 putChildren _ e@(PartyPar {}) = error "'putChildren l PartyPar' expects l to have 2 elements"
 putChildren _ e@(PartyReduce {}) = error "'putChildren l PartyReduce' expects l to have 3 elements"

--- a/src/types/Typechecker/Typechecker.hs
+++ b/src/types/Typechecker/Typechecker.hs
@@ -568,39 +568,6 @@ instance Checkable Expr where
            let eBody' = setType bodyType eBody
            return $ setType ty' $ te{body = eBody', ty = ty'}
 
-    doTypecheck l@(Liftf {val}) = do
-      e <- typecheck val
-      let typ = AST.getType e
-      unless (isFutureType typ) $
-             pushError e $ ExpectingOtherTypeError "a future" typ
-      return $ setType (parType $ getResultType typ) l {val = e}
-
-    doTypecheck l@(Liftv {val}) = do
-      e <- typecheck val
-      let typ = AST.getType e
-      return $ setType (parType typ) l {val = e}
-
-    doTypecheck p@(PartyJoin {val}) = do
-      e <- typecheck val
-      let typ = AST.getType e
-      unless (isParType typ && isParType (getResultType typ)) $
-             pushError e $ ExpectingOtherTypeError "a nested Par" typ
-      return $ setType (getResultType typ) p {val = e}
-
-    doTypecheck p@(PartyEach {val}) = do
-      e <- typecheck val
-      let typ = AST.getType e
-      unless (isArrayType typ) $
-             pushError e $ ExpectingOtherTypeError "an array" typ
-      return $ setType ((parType.getResultType) typ) p {val = e}
-
-    doTypecheck p@(PartyExtract {val}) = do
-      e <- typecheck val
-      let typ = AST.getType e
-      unless (isParType typ) $
-             pushError e $ ExpectingOtherTypeError "a Par" typ
-      return $ setType ((arrayType.getResultType) typ) p {val = e}
-
     doTypecheck p@(PartyPar {parl, parr}) = do
       pl <- typecheck parl
       pr <- hasType parr (AST.getType pl)


### PR DESCRIPTION
These nodes were only used for `OldParser.hs`, which has since been
removed. They are therefore dead code.