### PR TITLE
Truncate error messages

### DIFF
--- a/src/ir/AST/AST.hs
+++ b/src/ir/AST/AST.hs
@@ -810,6 +810,20 @@ isImpure NewWithInit {} = True
 isImpure New {} = True
 isImpure _ = False
 
+hasBody :: Expr -> Bool
+hasBody Closure {} = True
+hasBody Async {} = True
+hasBody Let {} = True
+hasBody IfThenElse {} = True
+hasBody IfThen {} = True
+hasBody Unless {} = True
+hasBody While {} = True
+hasBody DoWhile {} = True
+hasBody Repeat {} = True
+hasBody For {} = True
+hasBody Match {} = True
+hasBody _ = False
+
 instance HasMeta Expr where
     getMeta = emeta
     setMeta e m = e{emeta = m}


### PR DESCRIPTION
This commit fixes up the printing of the backtrace in error messages:

* No more than two expressions are printed, the deepest and second most
  deepest.
* The method/function and class/trait are always printed
* In case there are duplicates in the back-trace (which may happen due
  to desugaring), these are removed.
* Blocks inside blocked constructs are removed so that its printed
  ```
  while true do
    ...
  end
  ```
  rather than
  ```
  while true do
    do
      ...
    end
  end
  ```

There are no tests as this is a purely aesthetical change.