### PR TITLE
Allow active traits in modeless classes

### DIFF
--- a/src/back/CodeGen/Header.hs
+++ b/src/back/CodeGen/Header.hs
@@ -263,8 +263,8 @@ generateHeader p =
                  mparams = A.methodParams m
                  mtype = A.methodType m
 
-     wrapperMethods A.Class{A.cname, A.cmethods} =
-       if Ty.isPassiveRefType cname then
+     wrapperMethods c@A.Class{A.cname, A.cmethods} =
+       if A.isPassive c then
          []
        else
          map (genericMethod callMethodFutureName future) nonStreamMethods ++

--- a/src/ir/AST/Desugarer.hs
+++ b/src/ir/AST/Desugarer.hs
@@ -32,6 +32,7 @@ desugarProgram p@(Program{traits, classes, functions}) =
       | isActive c = c{cmethods = map desugarMethod (await:suspend:cmethods)}
       where
         await = Method{mmeta
+                      ,mimplicit = True
                       ,mheader=awaitHeader
                       ,mlocals=[]
                       ,mbody=Await emeta $ VarAccess emeta (qName "f")}
@@ -42,7 +43,11 @@ desugarProgram p@(Program{traits, classes, functions}) =
                             ,htype=unitType
                             ,hparams=[awaitParam]}
         awaitParam = Param{pmeta, pmut=Val, pname=Name "f", ptype=futureType $ typeVar "_t"}
-        suspend = Method{mmeta, mheader=suspendHeader, mlocals=[], mbody=Suspend emeta}
+        suspend = Method{mmeta
+                        ,mimplicit = True
+                        ,mheader = suspendHeader
+                        ,mlocals = []
+                        ,mbody = Suspend emeta}
         suspendHeader = Header{hmodifiers=[]
                               ,kind=NonStreaming
                               ,htypeparams=[]

--- a/src/parser/Parser/Parser.hs
+++ b/src/parser/Parser/Parser.hs
@@ -821,6 +821,7 @@ methodDecl = do
         alignedExpressions (buildMethod mmeta mheader)
     buildMethod mmeta mheader block =
       return Method{mmeta
+                   ,mimplicit = False
                    ,mheader
                    ,mbody = makeBody block
                    ,mlocals = []

--- a/src/tests/encore/traits/active.enc
+++ b/src/tests/encore/traits/active.enc
@@ -10,7 +10,7 @@ trait S
   end
 end
 
-active class C : T + S
+class C : active T + active S
 end
 
 active class Main

--- a/src/types/Typechecker/Prechecker.hs
+++ b/src/types/Typechecker/Prechecker.hs
@@ -250,9 +250,6 @@ instance Precheckable TraitComposition where
         unless (safeToComposeWith thisType tcname') $
                tcError $ ManifestClassConflictError
                          thisType tcname'
-        when (isActiveSingleType tcname') $
-             unless (isActiveSingleType thisType) $
-                    tcError $ ActiveTraitError tcname'
         mapM_ doPrecheck tcext
         return leaf{tcname = tcname'}
 
@@ -274,6 +271,12 @@ instance Precheckable ClassDecl where
                         cmethods
 
       checkShadowingMethodsAndFields cfields' cmethods'
+
+      let traits = typesFromTraitComposition ccomposition'
+          (activeTraits, nonActiveTraits) = partition isActiveSingleType traits
+      unless (null activeTraits) $
+        unless (null nonActiveTraits) $
+          tcError $ ActiveTraitError (head activeTraits) (head nonActiveTraits)
 
       return $ setType cname' c{ccomposition = ccomposition'
                                ,cfields = cfields'

--- a/src/types/Typechecker/TypeError.hs
+++ b/src/types/Typechecker/TypeError.hs
@@ -324,7 +324,7 @@ data Error =
   | ManifestConflictError Type Type
   | ManifestClassConflictError Type Type
   | UnmodedMethodExtensionError Type Name
-  | ActiveTraitError Type
+  | ActiveTraitError Type Type
   | NewWithModeError
   | UnsafeTypeArgumentError Type Type
   | SimpleError String
@@ -840,9 +840,10 @@ instance Show Error where
                 "  - Assign the method to an included trait: T(%s())")
                (show cls) (show name)
                "active, local, read, linear or subord" (show name)
-    show (ActiveTraitError trait) =
-        printf "Trait '%s' can only be included by active classes"
-               (show trait)
+    show (ActiveTraitError active nonActive) =
+        printf ("Active trait '%s' can only be included together with " ++
+                "other active traits. Found '%s'")
+               (showWithoutMode active) (show nonActive)
     show (UnsafeTypeArgumentError formal ty) =
         if isModeless ty then
           -- TODO: Could be more precise (e.g. distinguish between linear/subord)

--- a/src/types/Typechecker/Typechecker.hs
+++ b/src/types/Typechecker/Typechecker.hs
@@ -460,6 +460,7 @@ instance Checkable ClassDecl where
       extensionAllowed cap extensions method
         | isMainMethod cname (methodName method) = return ()
         | isConstructor method = return ()
+        | isImplicitMethod method = return ()
         | otherwise = do
             let name = methodName method
             lookupResult <- asks $ methodLookup cap name


### PR DESCRIPTION
The semantics still only allows active traits to be composed with
other active traits, but with this fix you don't have to make the
class itself `active`. The test for active traits has been adapted.

In other words, the following is now allowed:
```
trait T
  ...
end

class C : active T
  ...
end
```