### PR TITLE
Renamed field to remove warning

### DIFF
--- a/modules/standard/Task.enc
+++ b/modules/standard/Task.enc
@@ -126,11 +126,11 @@ fun Synchroniser[sharable t](f : Fut[t]) : Synchroniser[t]
 end
 
 active class Synchroniser[t]
-  var result : [t]
+  var res : [t]
   var countDown : int
   var callback : t -> unit
   def init(ar : [Fut[t]]) : unit
-    this.result = new [t](|ar|)
+    this.res = new [t](|ar|)
     this.countDown = |ar|
     var i = 0
     for f <- ar do
@@ -142,7 +142,7 @@ active class Synchroniser[t]
   end
   def fulfil(pos : int, r : t) : unit
     this.countDown = this.countDown - 1
-    (this.result)(pos) = r
+    (this.res)(pos) = r
   end
   def register(closure : t -> unit) : unit
     this.callback = closure
@@ -151,7 +151,7 @@ active class Synchroniser[t]
     while this.countDown > 0 do
       this.suspend()
     end
-    this.result
+    this.res
   end
 end
 #+END_SRC


### PR DESCRIPTION
This PR renames a field in one of the class `Synchroniser` in the `Task` module to eliminate the following warning:

> Warning at "~/encore/modules/standard/Task.enc" (line 129, column 3):
> Field 'result' holds an array and could be confused with the method of the same name
