### PR TITLE
Disallow silently capturing an active this as a passive reference

### DIFF
--- a/modules/standard/String.enc
+++ b/modules/standard/String.enc
@@ -11,11 +11,11 @@ BODY
 // This function is called in the very beginning of the program to
 // build an array containing the arguments of the program.
 array_t *_init_argv(pony_ctx_t** ctx, size_t argc, char **argv) {
- array_t *arr = array_mk(ctx, argc, &_enc__read_String_String_type);
+ array_t *arr = array_mk(ctx, argc, &_enc__class_String_String_type);
  for(int i = 0; i < argc; i++) {
-   _enc__read_String_String_t* s =
-     encore_alloc(*ctx, sizeof(_enc__read_String_String_t));
-   s->_enc__self_type = &_enc__read_String_String_type;
+   _enc__class_String_String_t* s =
+     encore_alloc(*ctx, sizeof(_enc__class_String_String_t));
+   s->_enc__self_type = &_enc__class_String_String_type;
    _enc__method_String_String_init(ctx, s, NULL, argv[i]);
    array_set(arr, i, (encore_arg_t){.p = s});
  }

--- a/src/back/CodeGen/CCodeNames.hs
+++ b/src/back/CodeGen/CCodeNames.hs
@@ -404,9 +404,7 @@ oneWayMsgId cls mname =
 typeNamePrefix :: Ty.Type -> String
 typeNamePrefix ref
   | Ty.isTraitType ref = encoreName "trait" qname
-  | Ty.isRefAtomType ref = if Ty.isModeless ref
-                           then encoreName "passive" qname
-                           else encoreName (showModeOf ref) qname
+  | Ty.isRefAtomType ref = encoreName "class" qname
   | otherwise = error $ "type_name_prefix Type '" ++ show ref ++
                         "' isnt reference type!"
   where

--- a/src/ir/AST/AST.hs
+++ b/src/ir/AST/AST.hs
@@ -429,6 +429,9 @@ instance HasMeta FieldDecl where
 isValField :: FieldDecl -> Bool
 isValField = (== Val) . fmut
 
+isVarField :: FieldDecl -> Bool
+isVarField = (== Var) . fmut
+
 data ParamDecl = Param {
   pmeta :: Meta ParamDecl,
   pmut  :: Mutability,

--- a/src/tests/encore/basic/valFields.enc
+++ b/src/tests/encore/basic/valFields.enc
@@ -39,7 +39,7 @@ local class Link[v] : Mappable[v](next)
   end
 end
 local class Stack[v] : Push[v]
-  val top : Mappable[v]
+  var top : Mappable[v]
   def init() : unit
     this.top = new Sentinel[v]()
   end

--- a/src/tests/encore/capabilities/activeThisFieldCapture.enc
+++ b/src/tests/encore/capabilities/activeThisFieldCapture.enc
@@ -1,0 +1,14 @@
+active class C
+  var f : int
+  def foo() : (() -> int)
+    fun () => this.f
+  end
+end
+
+active class Main
+  def main(args : [String]) : unit
+    val c = new C
+    val f = get(c!foo())
+    f()
+  end
+end

--- a/src/tests/encore/capabilities/activeThisFieldCapture.fail
+++ b/src/tests/encore/capabilities/activeThisFieldCapture.fail
@@ -1,0 +1,1 @@
+Closure of type 'local (() -> int)' captures local state and cannot be used as type '() -> int'

--- a/src/tests/encore/capabilities/activeThisMethodCapture.enc
+++ b/src/tests/encore/capabilities/activeThisMethodCapture.enc
@@ -1,0 +1,18 @@
+active class C
+  var f : int
+  def foo() : (() -> int)
+    fun () => this.f()
+  end
+  def f() : int
+    this.f = 0
+    42
+  end
+end
+
+active class Main
+  def main(args : [String]) : unit
+    val c = new C
+    val f = get(c!foo())
+    f()
+  end
+end

--- a/src/tests/encore/capabilities/activeThisMethodCapture.fail
+++ b/src/tests/encore/capabilities/activeThisMethodCapture.fail
@@ -1,0 +1,1 @@
+Closure of type 'local (() -> int)' captures local state and cannot be used as type '() -> int'

--- a/src/tests/encore/par/each.enc
+++ b/src/tests/encore/par/each.enc
@@ -26,11 +26,12 @@ active class Main
   def test_setting_array() : unit
     let
       arr = presetArray(this.size)
+      check_arr = this.check_arr
     in
       each(arr) >> fun (i : int)
-                     (this.check_arr)(i) = true
+                     check_arr(i) = true
                      i
-                   end >> fun (i : int) => assertTrue((this.check_arr)(i))
+                   end >> fun (i : int) => assertTrue(check_arr(i))
     end
   end
 

--- a/src/tests/encore/regressions/18.enc
+++ b/src/tests/encore/regressions/18.enc
@@ -2,8 +2,8 @@ local class Filter
   def cancel(i : int) : unit
     println(i)
   end
-  
-  def forall(f : int -> unit) : unit
+
+  def forall(f : local((int) -> unit)) : unit
     f(10)
   end
 end

--- a/src/tests/encore/traits/varRequire.enc
+++ b/src/tests/encore/traits/varRequire.enc
@@ -1,0 +1,7 @@
+trait T
+  require var f : int
+end
+
+class C : local T
+  val f : int
+end

--- a/src/tests/encore/traits/varRequire.fail
+++ b/src/tests/encore/traits/varRequire.fail
@@ -1,0 +1,1 @@
+Trait 'T' requires field 'val f : int' to be mutable

--- a/src/types/Typechecker/Typechecker.hs
+++ b/src/types/Typechecker/Typechecker.hs
@@ -211,6 +211,9 @@ meetRequiredFields cFields trait = do
         isSub <- cFieldType `subtypeOf` expected
         unless (cFieldType == expected) $
             tcError $ RequiredFieldMismatchError cField expected trait isSub
+        when (isVarField expField) $
+             unless (isVarField cField) $
+                 tcError $ RequiredFieldMutabilityError trait cField
 
 noOverlapFields :: Type -> Maybe TraitComposition -> TypecheckM ()
 noOverlapFields cname composition =
@@ -693,7 +696,12 @@ instance Checkable Expr where
             (header, calledType) <- findMethodWithCalledType targetType (name mcall)
 
             matchArgumentLength targetType header (args mcall)
-            let eTarget' = setType calledType eTarget
+
+            isActive <- isActiveType targetType
+            let eTarget' = if isThisAccess eTarget &&
+                              isActive && isMethodCall mcall
+                           then setType (makeLocal calledType) eTarget
+                           else setType calledType eTarget
                 typeParams = htypeparams header
                 argTypes = map ptype $ hparams header
                 resultType = htype header
@@ -1367,13 +1375,18 @@ instance Checkable Expr where
     doTypecheck fAcc@(FieldAccess {target, name}) = do
       eTarget <- typecheck target
       let targetType = AST.getType eTarget
+      isActive <- isActiveType targetType
+      let accessedType = if isThisAccess eTarget && isActive
+                         then makeLocal targetType
+                         else targetType
+          eTarget' = setType accessedType eTarget
       unless (isThisAccess target ||
               isPassiveClassType targetType && not (isModeless targetType)) $
         tcError $ CannotReadFieldError eTarget
       fdecl <- findField targetType name
       let ty = ftype fdecl
       checkFieldEncapsulation name eTarget ty
-      return $ setType ty fAcc {target = eTarget}
+      return $ setType ty fAcc {target = eTarget'}
 
     --  E |- lhs : t
     --  isLval(lhs)
@@ -1897,7 +1910,7 @@ checkSubordinateReturn name returnType targetType = do
   targetIsEncaps <- isEncapsulatedType targetType
   when subordReturn $
        unless targetIsEncaps $
-              tcError $ SubordinateReturnError name
+              tcError $ SubordinateReturnError name returnType
 
 checkSubordinateArgs :: [Expr] -> Type -> TypecheckM ()
 checkSubordinateArgs args targetType = do
@@ -1944,7 +1957,7 @@ checkLocalReturn name returnType targetType =
   when (isActiveSingleType targetType) $ do
     localReturn <- isLocalType returnType
     when localReturn $
-       tcError $ ThreadLocalReturnError name
+       tcError $ ThreadLocalReturnError name returnType
     let nonSharable =
           find nonSharableTypeVar $ typeComponents returnType
     when (isJust nonSharable) $

--- a/src/types/Types.hs
+++ b/src/types/Types.hs
@@ -680,6 +680,8 @@ withModeOf sink source
     , info <- refInfo iType
     , mode <- mode $ refInfo (inner source)
       = sink{inner = iType{refInfo = info{mode}}}
+    | isArrowType sink && isArrowType source
+    , modes <- getModes source = applyInner (\i -> i{modes}) sink
     | otherwise =
         error $ "Types.hs: Can't transfer modes from " ++
                 showWithKind source ++ " to " ++ showWithKind sink


### PR DESCRIPTION
Before this commit, in an `active` class, you could use `this` to
access fields or (synchronously) call methods inside a closure.
Because the mode of `this` is `active`, which is safe, the mode of
the closure would allow it to be shared, leading to potential
data-races. This commit changes an `active` `this` to a `local`
variable if it is used for synchronous accesses. This forces the
`local` mode on a closure containing e.g. `this.foo()`.

There are also some improved error messages and a small check for
when a required `var` field is provided as a `val` field.

Fixes #781.