### PR TITLE
Print file and line number for uncaught matches

### DIFF
--- a/src/tests/encore/match/missing.enc
+++ b/src/tests/encore/match/missing.enc
@@ -1,0 +1,9 @@
+active class Main
+  def main(args : [String]) : unit
+    match 1 with
+      case 2 =>
+        println("This should not happen!")
+      end
+    end
+  end
+end

--- a/src/tests/encore/match/missing.err
+++ b/src/tests/encore/match/missing.err
@@ -1,0 +1,1 @@
+*** Runtime error: No matching clause was found at "missing.enc" (line 3, column 5) ***


### PR DESCRIPTION
This commit adds to the error message the position of a match
expression when no case matches. A test has been added.

Fixes #733.