### PR TITLE
Fix bug when printing non-sugared strings

### DIFF
--- a/src/ir/AST/Meta.hs
+++ b/src/ir/AST/Meta.hs
@@ -68,7 +68,7 @@ setType newType m = m {metaType = Just newType}
 getType :: Meta a -> Type
 getType m = fromMaybe err (metaType m)
     where
-      err = error "Meta.hs: No type given to node"
+      err = error $ "Meta.hs: No type given to node at " ++ showPos m
 
 setSugared :: a -> Meta a -> Meta a
 setSugared s m = m {sugared = Just s}

--- a/src/opt/Optimizer/Optimizer.hs
+++ b/src/opt/Optimizer/Optimizer.hs
@@ -117,7 +117,7 @@ sugarPrintedStrings = extend sugarPrintedString
       simplifyStringLit arg
         | NewWithInit{ty} <- arg
         , isStringObjectType ty
-        , Just sugared <- getSugared arg
+        , Just sugared@StringLiteral{} <- getSugared arg
           = setType stringType sugared
         | otherwise = arg
 

--- a/src/tests/encore/print/embed.enc
+++ b/src/tests/encore/print/embed.enc
@@ -1,0 +1,6 @@
+active class Main
+  def main() : unit
+    print(new String(EMBED (EMBED char* END) "The answer is: "; END))
+    println(new String(EMBED (EMBED char* END) "42"; END))
+  end
+end

--- a/src/tests/encore/print/embed.out
+++ b/src/tests/encore/print/embed.out
@@ -1,0 +1,1 @@
+The answer is: 42


### PR DESCRIPTION
Printing a string created using `new` would break:

```
println(new String(EMBED (EMBED char* END) "foo"; END))
```

This commit fixes this, adds a test for it, and also improves the
error message of `Meta.hs: No type given to node` so that it
prints the source position of the node that was not given a type,
which should help when debugging similar errors in the future.