### PR TITLE
Maybe, Par etc are no longer reserved

### DIFF
--- a/modules/standard/Stream/Chain.enc
+++ b/modules/standard/Stream/Chain.enc
@@ -1,7 +1,7 @@
--- This file was automatically converted by encorec
+module Chain
 
-module StreamChain
 typedef Scons = EMBED struct scons* END
+
 fun chain[a, b](sa : Stream[a], f : a -> b) : Stream[b]
   let
     futa = EMBED (Fut[Scons])

--- a/src/parser/Parser/Parser.hs
+++ b/src/parser/Parser/Parser.hs
@@ -185,10 +185,6 @@ buildMeta = meta . newPos <$> getPosition
 reservedNames =
     ["EMBED"
     ,"END"
-    ,"Fut"
-    ,"Maybe"
-    ,"Par"
-    ,"Stream"
     ,"active"
     ,"and"
     ,"bool"

--- a/src/tests/encore/basic/MaybeRedefine.enc
+++ b/src/tests/encore/basic/MaybeRedefine.enc
@@ -1,0 +1,12 @@
+
+
+read class Maybe
+end
+
+active class Main
+  def main() : unit
+    val x = Just(10)
+    val y = new Maybe[int]()
+    10
+  end
+end

--- a/src/tests/encore/basic/MaybeRedefine.fail
+++ b/src/tests/encore/basic/MaybeRedefine.fail
@@ -1,0 +1,2 @@
+Types Maybe, Fut, Stream, and Par are built-in and cannot be redefined.
+

--- a/src/tests/encore/stream/StreamIO.enc
+++ b/src/tests/encore/stream/StreamIO.enc
@@ -1,6 +1,6 @@
--- This file was automatically converted by encorec
 
 module StreamIO
+
 active class StreamIO
   stream produceInt(n : int) : int
     var i = n
@@ -9,6 +9,7 @@ active class StreamIO
       i = i - 1
     end
   end
+  
   stream produceReal(n : int) : real
     var i = n
     while i > 0 do
@@ -16,6 +17,7 @@ active class StreamIO
       i = i - 1
     end
   end
+  
   def printStreamReal(sr : Stream[real]) : unit
     var str = sr
     while not(eos(str)) do
@@ -23,6 +25,7 @@ active class StreamIO
       str = getNext(str)
     end
   end
+  
   def printStreamInt(si : Stream[int]) : unit
     var str = si
     while not(eos(str)) do

--- a/src/tests/encore/stream/streamChainInt.enc
+++ b/src/tests/encore/stream/streamChainInt.enc
@@ -1,4 +1,4 @@
-import StreamLib.StreamChain.StreamChain
+import Stream.Chain
 import StreamIO
 
 active class Main

--- a/src/tests/encore/stream/streamChainReal.enc
+++ b/src/tests/encore/stream/streamChainReal.enc
@@ -1,6 +1,4 @@
--- This file was automatically converted by encorec
-
-import StreamLib.StreamChain.StreamChain
+import Stream.Chain
 import StreamIO
 active class Main
   def main() : unit

--- a/src/tests/encore/stream/streamEos.enc
+++ b/src/tests/encore/stream/streamEos.enc
@@ -1,4 +1,3 @@
--- This file was automatically converted by encorec
 
 active class Foo
   stream bar() : int

--- a/src/tests/encore/stream/streamSyncCall.enc
+++ b/src/tests/encore/stream/streamSyncCall.enc
@@ -1,9 +1,10 @@
--- This file was automatically converted by encorec
 
 active class Foo
+
   stream foo1() : int
     yield(1)
   end
+
   stream foo2() : int
     let
       foo3 = this.foo1()
@@ -12,6 +13,7 @@ active class Foo
     end
   end
 end
+
 active class Main
   def main() : unit
     ()

--- a/src/types/Typechecker/Prechecker.hs
+++ b/src/types/Typechecker/Prechecker.hs
@@ -76,10 +76,7 @@ instance Precheckable Program where
         assertDistinct "definition" functions
         assertDistinct "definition" traits
         assertDistinct "definition" classes
-        assertDistinctThing "declaration" "typedef, class or trait name" $
-                            map (getId . tname) traits ++
-                            map (getId . cname) classes ++
-                            map (getId . typedefdef) typedefs
+        assertDistinctThing "declaration" "typedef, class or trait name" $ newTypeNames
       assertCorrectModuleName _ NoModule = return ()
       assertCorrectModuleName source m@Module{modname} = do
         let sourceName = basename source
@@ -100,11 +97,11 @@ instance Precheckable Program where
                   find ((== Just (itarget shadowedImport)) . ialias) imports
           pushError illegalAlias $ ShadowedImportError shadowedImport
       assertNonOverlapWithPredefineds = 
-        when (or (map (`elem` ["Maybe", "Fut", "Stream", "Par"]) $
-                              map (getId . tname) traits ++
-                              map (getId . cname) classes ++
-                              map (getId . typedefdef) typedefs)) $
+        when (or (map (`elem` ["Maybe", "Fut", "Stream", "Par"]) newTypeNames)) $
                 tcError OverlapWithBuiltins 
+      newTypeNames = map (getId . tname) traits ++
+                     map (getId . cname) classes ++
+                     map (getId . typedefdef) typedefs
 
 instance Precheckable ModuleDecl where
     doPrecheck m@NoModule = return m

--- a/src/types/Typechecker/Prechecker.hs
+++ b/src/types/Typechecker/Prechecker.hs
@@ -60,6 +60,7 @@ instance Precheckable Program where
       precheck moduledecl
       assertCorrectModuleName source moduledecl
       assertNoShadowedImports
+      assertNonOverlapWithPredefineds
       mapM_ precheck imports
       typedefs'  <- mapM precheck typedefs
       functions' <- mapM precheck functions
@@ -98,7 +99,12 @@ instance Precheckable Program where
                 fromJust $
                   find ((== Just (itarget shadowedImport)) . ialias) imports
           pushError illegalAlias $ ShadowedImportError shadowedImport
-
+      assertNonOverlapWithPredefineds = 
+        when (or (map (`elem` ["Maybe", "Fut", "Stream", "Par"]) $
+                              map (getId . tname) traits ++
+                              map (getId . cname) classes ++
+                              map (getId . typedefdef) typedefs)) $
+                tcError OverlapWithBuiltins 
 
 instance Precheckable ModuleDecl where
     doPrecheck m@NoModule = return m

--- a/src/types/Typechecker/TypeError.hs
+++ b/src/types/Typechecker/TypeError.hs
@@ -327,6 +327,7 @@ data Error =
   | ActiveTraitError Type Type
   | NewWithModeError
   | UnsafeTypeArgumentError Type Type
+  | OverlapWithBuiltins
   | SimpleError String
   ----------------------------
   -- Capturechecking errors --
@@ -871,6 +872,8 @@ instance Show Error where
                  (getId formal) (if isModeless formal
                                  then "an aliasable"
                                  else showModeOf formal)
+    show OverlapWithBuiltins =
+      printf ("Types Maybe, Fut, Stream, and Par are built-in and cannot be redefined.") 
     show (SimpleError msg) = msg
     ----------------------------
     -- Capturechecking errors --


### PR DESCRIPTION
This PR makes Maybe, Fut, Par and Stream no longer reserved names in the parser. This means that the names Maybe etc can be used more freely within the code, in particular (and most importantly), as the name of a module. (They cannot be used as the name of a new type.) This will be useful when creating a module of functions for Maybe, which can now be called `module Maybe`.

Additional checking has been added to ensure that new classes etc are not called Maybe etc.

In addition, StreamLib was renamed to Stream (and reorganised slightly).