### PR TITLE
fix array access

### DIFF
--- a/src/tests/encore/basic/arrayAccess.enc
+++ b/src/tests/encore/basic/arrayAccess.enc
@@ -1,0 +1,6 @@
+active class Main
+  def main(): unit
+    val i = 4
+    i(0) = 3
+  end
+end

--- a/src/tests/encore/basic/arrayAccess.fail
+++ b/src/tests/encore/basic/arrayAccess.fail
@@ -1,1 +1,1 @@
-Expected an array access or a function call but found expression of type 'int'
+Expected an array or a function call but found expression of type 'int'

--- a/src/tests/encore/basic/arrayAccess.fail
+++ b/src/tests/encore/basic/arrayAccess.fail
@@ -1,0 +1,1 @@
+Expected an array access or a function call but found expression of type 'int'

--- a/src/types/Typechecker/Typechecker.hs
+++ b/src/types/Typechecker/Typechecker.hs
@@ -824,8 +824,6 @@ instance Checkable Expr where
                   Just (qname2, ty2) -> return defName
                   Nothing -> tcError $ WrongNumberOfFunctionArgumentsError
                               qname (length argTypes) (length args)
-          unless (isArrowType ty) $
-            tcError $ NonFunctionTypeError ty
           (eArgs, returnType, typeArgs) <-
             if null typeArguments
             then inferenceCall fcall typeParams (take actualLength argTypes) resultType

--- a/src/types/Typechecker/Typechecker.hs
+++ b/src/types/Typechecker/Typechecker.hs
@@ -840,7 +840,7 @@ instance Checkable Expr where
                                              typeArguments = typeArgs}
         else do
           tcError $
-             ExpectingOtherTypeError "an array access or a function call" ty
+             ExpectingOtherTypeError "an array or a function call" ty
 
    ---  |- t1 .. |- tn
     --  E, x1 : t1, .., xn : tn |- body : t

--- a/src/types/Typechecker/Typechecker.hs
+++ b/src/types/Typechecker/Typechecker.hs
@@ -807,8 +807,7 @@ instance Checkable Expr where
           doTypecheck ArrayAccess{emeta
                                  ,target = VarAccess{emeta, qname}
                                  ,index = head args}
-      else
-        if (isArrowType ty) then do
+      else if (isArrowType ty) then do
           let typeParams  = getTypeParameters ty
               argTypes    = getArgTypes ty
               resultType  = getResultType ty


### PR DESCRIPTION
This commit fixes accesses to an array when the type is different from an array; closes #823 and #831 

This test case used to crash the compiler
```
active class Main
  def main(): unit
    val i = 4
    i(0) = 3
  end
end
```

With this commit, the compiler informs you that it expects an array of a function call and you gave it an int type.
