### PR TITLE
Fixed bug where polymorphic methods could not be overridden

### DIFF
--- a/src/tests/encore/traits/overridingMethodMismatch.enc
+++ b/src/tests/encore/traits/overridingMethodMismatch.enc
@@ -1,0 +1,11 @@
+read trait T
+  def foo(x : int) : int
+    x
+  end
+end
+
+class C : T
+  def foo(x : int) : String
+    string_from_int(x)
+  end
+end

--- a/src/tests/encore/traits/overridingMethodMismatch.fail
+++ b/src/tests/encore/traits/overridingMethodMismatch.fail
@@ -1,0 +1,1 @@
+Overridden method 'foo' does not have the expected type 'int -> int' required by trait 'T'

--- a/src/tests/encore/traits/overridingMethodMismatchPoly.enc
+++ b/src/tests/encore/traits/overridingMethodMismatchPoly.enc
@@ -1,0 +1,11 @@
+read trait T
+  def foo[t](x : int) : int
+    x
+  end
+end
+
+class C : T
+  def foo(x : int) : int
+    x
+  end
+end

--- a/src/tests/encore/traits/overridingMethodMismatchPoly.fail
+++ b/src/tests/encore/traits/overridingMethodMismatchPoly.fail
@@ -1,0 +1,1 @@
+Overridden method 'foo' does not have the expected type '\\[t\\](int -> int)' required by trait 'T'

--- a/src/tests/encore/traits/overridingMethodMismatchPoly2.enc
+++ b/src/tests/encore/traits/overridingMethodMismatchPoly2.enc
@@ -1,0 +1,11 @@
+read trait T
+  def foo[t](x : t) : t
+    x
+  end
+end
+
+class C : T
+  def foo[t, s](x : t) : t
+    x
+  end
+end

--- a/src/tests/encore/traits/overridingMethodMismatchPoly2.fail
+++ b/src/tests/encore/traits/overridingMethodMismatchPoly2.fail
@@ -1,0 +1,1 @@
+Overridden method 'foo' does not have the expected type '\\[t\\](t -> t)' required by trait 'T'

--- a/src/tests/encore/traits/overridingPolyMethod.enc
+++ b/src/tests/encore/traits/overridingPolyMethod.enc
@@ -1,0 +1,17 @@
+trait T
+  def foo[t](x : t) : t
+    x
+  end
+end
+
+class C : local T
+  def foo[u](x : u) : u
+    x
+  end
+end
+
+active class Main
+  def main(args : [String]) : unit
+    println((new C).foo("I compile and run!"))
+  end
+end

--- a/src/tests/encore/traits/overridingPolyMethod.out
+++ b/src/tests/encore/traits/overridingPolyMethod.out
@@ -1,0 +1,1 @@
+I compile and run!

--- a/src/types/Typechecker/TypeError.hs
+++ b/src/types/Typechecker/TypeError.hs
@@ -204,7 +204,7 @@ data Error =
   | CovarianceViolationError FieldDecl Type Type
   | RequiredFieldMismatchError FieldDecl Type Type Bool
   | NonDisjointConjunctionError Type Type FieldDecl
-  | OverriddenMethodTypeError Name Type Type
+  | OverriddenMethodTypeError Name Type Type Type
   | OverriddenMethodError Name Type Error
   | IncludedMethodConflictError Name Type Type
   | MissingMethodRequirementError FunctionHeader Type
@@ -391,10 +391,11 @@ instance Show Error where
         printf
           "Conjunctive traits '%s' and '%s' cannot share mutable field '%s'"
            (show left) (show right) (show field)
-    show (OverriddenMethodTypeError name expected trait) =
+    show (OverriddenMethodTypeError name expected trait actual) =
         printf ("Overridden method '%s' does not " ++
-                "have the expected type '%s' required by %s")
-               (show name) (show expected) (refTypeName trait)
+                "have the expected type '%s' required by %s.\n" ++
+                "Actual type is '%s'")
+               (show name) (show expected) (refTypeName trait) (show actual)
     show (OverriddenMethodError name trait err) =
         case err of
           FieldNotFoundError f _ ->
@@ -873,7 +874,7 @@ instance Show Error where
                                  then "an aliasable"
                                  else showModeOf formal)
     show OverlapWithBuiltins =
-      printf ("Types Maybe, Fut, Stream, and Par are built-in and cannot be redefined.") 
+      printf ("Types Maybe, Fut, Stream, and Par are built-in and cannot be redefined.")
     show (SimpleError msg) = msg
     ----------------------------
     -- Capturechecking errors --

--- a/src/types/Typechecker/Typechecker.hs
+++ b/src/types/Typechecker/Typechecker.hs
@@ -380,15 +380,19 @@ checkOverriding cname typeParameters methods extendedTraits = do
     checkOverride typeParameters (abstractDecl, required, method) = do
       let expectedParamTypes = map ptype $ hparams required
           expectedType = htype required
+          expectedTypeParams = htypeparams required
           expectedMethodType = arrowType expectedParamTypes expectedType
+                               `setTypeParameters` expectedTypeParams
           actualParamTypes = map ptype $ methodParams method
           actualType = methodType method
+          actualTypeParams = methodTypeParams method
           actualMethodType = arrowType actualParamTypes actualType
+                             `setTypeParameters` actualTypeParams
           requirer = tname abstractDecl
       unlessM (actualMethodType `subtypeOf` expectedMethodType) $
              pushError method $
                OverriddenMethodTypeError
-                 (methodName method) expectedMethodType requirer
+                 (methodName method) expectedMethodType requirer actualMethodType
       typecheckWithTrait `catchError`
                           \(TCError e bt) ->
                              throwError $

--- a/src/types/Typechecker/Util.hs
+++ b/src/types/Typechecker/Util.hs
@@ -285,13 +285,17 @@ subtypeOf ty1 ty2
     | isStackboundType ty1 =
         liftM (isStackboundType ty2 &&) $ unbox ty1 `subtypeOf` unbox ty2
     | isArrowType ty1 && isArrowType ty2 = do
-        let argTys1 = getArgTypes ty1
-            argTys2 = getArgTypes ty2
+        let typeParams1 = getTypeParameters ty1
+            typeParams2 = getTypeParameters ty2
+            bindings = zip typeParams2 typeParams1
             resultTy1 = getResultType ty1
-            resultTy2 = getResultType ty2
+            resultTy2 = replaceTypeVars bindings $ getResultType ty2
+            argTys1 = getArgTypes ty1
+            argTys2 = map (replaceTypeVars bindings) $ getArgTypes ty2
         contravariance <- liftM and $ zipWithM subtypeOf argTys2 argTys1
         covariance <- resultTy1 `subtypeOf` resultTy2
         return $ length argTys1 == length argTys2 &&
+                 length typeParams1 == length typeParams2 &&
                  ty1 `modeSubtypeOf` ty2 &&
                  contravariance && covariance
     | hasResultType ty1 && hasResultType ty2 =

--- a/src/types/Types.hs
+++ b/src/types/Types.hs
@@ -423,17 +423,21 @@ instance Show InnerType where
     show t@TypeVar{tmode = Nothing, ident = ('_':ident')} = show t{ident = ident'}
     show t@TypeVar{tmode = Nothing, ident} = ident
     show t@TypeVar{tmode = Just m} = show m ++ " " ++ show t{tmode = Nothing}
-    show ArrowType{argTypes = [ty], resultType, modes = []} =
+    show ArrowType{argTypes = [ty], resultType, modes = [], paramTypes = []} =
         if isTupleType ty
         then "(" ++ show ty ++ ") -> " ++ show resultType
         else show ty ++ " -> " ++ show resultType
-    show ArrowType{argTypes, resultType, modes = []} =
+    show ArrowType{argTypes, resultType, modes = [], paramTypes = []} =
         "(" ++ args ++ ") -> " ++ show resultType
         where
           args = intercalate ", " (map show argTypes)
-    show arrow@ArrowType{modes} =
+    show arrow@ArrowType{modes, paramTypes = []} =
         unwords (map show modes) ++
         " (" ++ show arrow{modes = []} ++ ")"
+    show arrow@ArrowType{paramTypes} =
+        "[" ++ params ++ "](" ++ show arrow{paramTypes = []} ++ ")"
+        where
+          params = intercalate ", " (map show paramTypes)
     show FutureType{resultType} = "Fut" ++ brackets resultType
     show ParType{resultType}    = "Par" ++ brackets resultType
     show StreamType{resultType} = "Stream" ++ brackets resultType


### PR DESCRIPTION
This commit fixes a bug where polymorphic methods could not be
overridden if the names of the type parameters were
different (which they would always be since traits mangle their
names to avoid clashes).