### PR TITLE
Fixed printing bottom problem

### DIFF
--- a/src/back/CodeGen/Type.hs
+++ b/src/back/CodeGen/Type.hs
@@ -40,6 +40,7 @@ instance Translatable Ty.Type (CCode Ty) where
         | Ty.isTupleType ty      = tuple
         | Ty.isCType ty          = Embed $ Ty.getId ty
         | Ty.isParType ty        = par
+        | Ty.isBottomType ty     = Ptr void
         | otherwise = error $ "I don't know how to translate "++ show ty ++" to pony.c"
 
 runtimeType :: Ty.Type -> CCode Expr

--- a/src/tests/encore/regressions/836.enc
+++ b/src/tests/encore/regressions/836.enc
@@ -1,0 +1,5 @@
+active class Main
+  def main() : unit
+    println("{}", Nothing)
+  end
+end

--- a/src/tests/encore/regressions/836.out
+++ b/src/tests/encore/regressions/836.out
@@ -1,0 +1,1 @@
+Nothing


### PR DESCRIPTION
This PR converts BottomType to (void *) in code generation, rather than generating an error. My argument that this is safe is that anything of BottomType (or involving BottomType) never produces a value of BottomType, so the actual type could be anything. 

This fix was also tested with a larger program that had the same error in a different branch, but I was unable to reproduce that error in this branch.
Fixes #836.