### PR TITLE
Fix bug when overriding bounded polymorphic methods

### DIFF
--- a/src/tests/encore/traits/overridingMethodBound.enc
+++ b/src/tests/encore/traits/overridingMethodBound.enc
@@ -1,0 +1,30 @@
+read trait S[t]
+  def id(x : t) : t
+    x
+  end
+end
+
+read trait T
+  def foo[t, s : S[t]](x : t, y : s) : t
+    x
+  end
+end
+
+read class C : T
+  def foo[a, b : S[a]](x : a, y : b) : a
+    y.id(x)
+  end
+  def bar() : unit
+    println("We made it!")
+  end
+end
+
+class D : S[C]
+end
+
+active class Main
+  def main(args : [String]) : unit
+    val c = new C
+    c.foo(c, new D).bar()
+  end
+end

--- a/src/tests/encore/traits/overridingMethodBound.out
+++ b/src/tests/encore/traits/overridingMethodBound.out
@@ -1,0 +1,1 @@
+We made it!

--- a/src/tests/encore/traits/overridingMethodBoundMismatch.enc
+++ b/src/tests/encore/traits/overridingMethodBoundMismatch.enc
@@ -1,0 +1,17 @@
+read trait S[t]
+  def id(x : t) : t
+    x
+  end
+end
+
+read trait T
+  def foo[t, s : S[t]](x : t, y : s) : t
+    x
+  end
+end
+
+read class C : T
+  def foo[t, s](x : t, y : s) : t
+    x
+  end
+end

--- a/src/tests/encore/traits/overridingMethodBoundMismatch.fail
+++ b/src/tests/encore/traits/overridingMethodBoundMismatch.fail
@@ -1,0 +1,1 @@
+Overridden method 'foo' does not have the expected type '\\[t, s : read S\\[t\\]\\]((t, s) -> t)' required by trait 'T'

--- a/src/types/Typechecker/Util.hs
+++ b/src/types/Typechecker/Util.hs
@@ -161,7 +161,7 @@ resolveSingleType :: Type -> TypecheckM Type
 resolveSingleType ty
   | isTypeVar ty = do
       params <- asks typeParameters
-      case find ((getId ty ==) . getId) params of
+      case find (ty ==) params of
         Just ty' -> return $ ty' `withBoxOf` ty
         Nothing  -> tcError $ FreeTypeVariableError ty
   | isRefAtomType ty = do


### PR DESCRIPTION
See the added test cases for what used to fail before (and what
still correctly fails). In short, bounds for type parameters would
not get translated correctly when doing name mangling for trait
methods.