### PR TITLE
Improved names for `subtypeOf`

### DIFF
--- a/src/types/Typechecker/Util.hs
+++ b/src/types/Typechecker/Util.hs
@@ -318,88 +318,88 @@ checkTypeArgumentBounds params args =
       | otherwise = return ()
 
 subtypeOf :: Type -> Type -> TypecheckM Bool
-subtypeOf ty1 ty2
-    | isStackboundType ty1 =
-        liftM (isStackboundType ty2 &&) $ unbox ty1 `subtypeOf` unbox ty2
-    | isArrowType ty1 && isArrowType ty2 = do
-        let typeParams1 = getTypeParameters ty1
-            typeParams2 = getTypeParameters ty2
-            bindings = zip typeParams2 typeParams1
-            resultTy1 = getResultType ty1
-            resultTy2 = replaceTypeVars bindings $ getResultType ty2
-            argTys1 = getArgTypes ty1
-            argTys2 = map (replaceTypeVars bindings) $ getArgTypes ty2
-            bounds1 = map getBound typeParams1
-            bounds2 = map (fmap (replaceTypeVars bindings) . getBound) typeParams2
-        contravariance <- liftM and $ zipWithM subtypeOf argTys2 argTys1
-        covariance <- resultTy1 `subtypeOf` resultTy2
-        return $ length argTys1 == length argTys2 &&
-                 length typeParams1 == length typeParams2 &&
-                 bounds1 == bounds2 &&
-                 ty1 `modeSubtypeOf` ty2 &&
+subtypeOf sub super
+    | isStackboundType sub =
+        liftM (isStackboundType super &&) $ unbox sub `subtypeOf` unbox super
+    | isArrowType sub && isArrowType super = do
+        let subTypeParams = getTypeParameters sub
+            superTypeParams = getTypeParameters super
+            bindings = zip superTypeParams subTypeParams
+            subResultTy = getResultType sub
+            superResultType = replaceTypeVars bindings $ getResultType super
+            subArgTys = getArgTypes sub
+            superArgTys = map (replaceTypeVars bindings) $ getArgTypes super
+            subBounds = map getBound subTypeParams
+            superBounds = map (fmap (replaceTypeVars bindings) . getBound) superTypeParams
+        contravariance <- liftM and $ zipWithM subtypeOf superArgTys subArgTys
+        covariance <- subResultTy `subtypeOf` superResultType
+        return $ length subArgTys == length superArgTys &&
+                 length subTypeParams == length superTypeParams &&
+                 subBounds == superBounds &&
+                 sub `modeSubtypeOf` super &&
                  contravariance && covariance
-    | isArrayType ty1 && isArrayType ty2 =
-        getResultType ty1 `equivalentTo` getResultType ty2
-    | hasResultType ty1 && hasResultType ty2 =
-        liftM (ty1 `hasSameKind` ty2 &&) $
-              getResultType ty1 `subtypeOf` getResultType ty2
-    | isNullType ty1 = return (isNullType ty2 || isRefType ty2)
-    | isClassType ty1 && isClassType ty2 =
-        return $ ty1 == ty2
-    | isClassType ty1 && isCapabilityType ty2 = do
-        capability <- findCapability ty1
-        capability `capabilitySubtypeOf` ty2
-    | isTupleType ty1 && isTupleType ty2 = do
-      let argTys1 = getArgTypes ty1
-          argTys2 = getArgTypes ty2
-      results <- zipWithM subtypeOf argTys1 argTys2
-      return $ and results && length argTys1 == length argTys2
-    | isAbstractTraitType ty1 && isTraitType ty2 =
-        return $ ty1 == abstractTraitFromTraitType ty2
-    | isTraitType ty1 && isAbstractTraitType ty2 =
-        return $ abstractTraitFromTraitType ty1 == ty2
-    | isTraitType ty1 && isTraitType ty2 =
-        return $ ty1 `modeSubtypeOf` ty2 &&
-                 ty1 == ty2
-    | isTraitType ty1 && isCapabilityType ty2 = do
-        let traits = typesFromCapability ty2
-        allM (ty1 `subtypeOf`) traits
-    | isCapabilityType ty1 && isTraitType ty2 = do
-        let traits = typesFromCapability ty1
-        anyM (`subtypeOf` ty2) traits
-    | isCapabilityType ty1 && isCapabilityType ty2 =
-        ty1 `capabilitySubtypeOf` ty2
-    | isUnionType ty1 && isUnionType ty2 = do
-        let members1 = unionMembers ty1
-            members2 = unionMembers ty2
+    | isArrayType sub && isArrayType super =
+        getResultType sub `equivalentTo` getResultType super
+    | hasResultType sub && hasResultType super =
+        liftM (sub `hasSameKind` super &&) $
+              getResultType sub `subtypeOf` getResultType super
+    | isNullType sub = return (isNullType super || isRefType super)
+    | isClassType sub && isClassType super =
+        return $ sub == super
+    | isClassType sub && isCapabilityType super = do
+        capability <- findCapability sub
+        capability `capabilitySubtypeOf` super
+    | isTupleType sub && isTupleType super = do
+      let subArgTys = getArgTypes sub
+          superArgTys = getArgTypes super
+      results <- zipWithM subtypeOf subArgTys superArgTys
+      return $ and results && length subArgTys == length superArgTys
+    | isAbstractTraitType sub && isTraitType super =
+        return $ sub == abstractTraitFromTraitType super
+    | isTraitType sub && isAbstractTraitType super =
+        return $ abstractTraitFromTraitType sub == super
+    | isTraitType sub && isTraitType super =
+        return $ sub `modeSubtypeOf` super &&
+                 sub == super
+    | isTraitType sub && isCapabilityType super = do
+        let traits = typesFromCapability super
+        allM (sub `subtypeOf`) traits
+    | isCapabilityType sub && isTraitType super = do
+        let traits = typesFromCapability sub
+        anyM (`subtypeOf` super) traits
+    | isCapabilityType sub && isCapabilityType super =
+        sub `capabilitySubtypeOf` super
+    | isUnionType sub && isUnionType super = do
+        let members1 = unionMembers sub
+            members2 = unionMembers super
         allM (\ty -> anyM (ty `subtypeOf`) members2) members1
-    | isUnionType ty1 = do
-        let members1 = unionMembers ty1
-        allM (`subtypeOf` ty2) members1
-    | isUnionType ty2 = do
-        let members2 = unionMembers ty2
-        anyM (ty1 `subtypeOf`) members2
-    | isBottomType ty1 && (not . isBottomType $ ty2) = return True
-    | isNumeric ty1 && isNumeric ty2 =
-        return $ ty1 `numericSubtypeOf` ty2
-    | isTypeVar ty1 && not (isTypeVar ty2)
-    , Just bound <- getBound ty1
-      = bound `subtypeOf` ty2
-    | otherwise = return (ty1 == ty2)
+    | isUnionType sub = do
+        let members1 = unionMembers sub
+        allM (`subtypeOf` super) members1
+    | isUnionType super = do
+        let members2 = unionMembers super
+        anyM (sub `subtypeOf`) members2
+    | isBottomType sub && (not . isBottomType $ super) = return True
+    | isNumeric sub && isNumeric super =
+        return $ sub `numericSubtypeOf` super
+    | isTypeVar sub && not (isTypeVar super)
+    , Just bound <- getBound sub
+      = bound `subtypeOf` super
+    | otherwise = return (sub == super)
     where
-      capabilitySubtypeOf cap1 cap2 = do
-        let traits1 = typesFromCapability cap1
-            traits2 = typesFromCapability cap2
-            preservesConjunctions = cap1 `preservesConjunctionsOf` cap2
+      capabilitySubtypeOf subCap superCap = do
+        let traits1 = typesFromCapability subCap
+            traits2 = typesFromCapability superCap
+            preservesConjunctions = subCap `preservesConjunctionsOf` superCap
             preservesModes =
               all (\t1 -> isReadSingleType t1 || isLinearSingleType t1 ||
                           any (`modeSubtypeOf` t1) traits2) traits1
         isSubsumed <- allM (\t2 -> anyM (`subtypeOf` t2) traits1) traits2
         return (preservesConjunctions && preservesModes && isSubsumed)
 
-      preservesConjunctionsOf cap1 cap2 =
-        let pairs1 = conjunctiveTypesFromCapability cap1
-            pairs2 = conjunctiveTypesFromCapability cap2
+      preservesConjunctionsOf subCap superCap =
+        let pairs1 = conjunctiveTypesFromCapability subCap
+            pairs2 = conjunctiveTypesFromCapability superCap
         in all (`existsIn` pairs1) pairs2
       existsIn (left, right) =
         any (separates left right)
@@ -407,11 +407,11 @@ subtypeOf ty1 ty2
         all (`elem` l) left && all (`elem` r) right ||
         all (`elem` l) right && all (`elem` r) left
 
-      numericSubtypeOf ty1 ty2
-          | isIntType ty1 && isRealType ty2 = True
-          | isIntType ty1 && isUIntType ty2 = True
-          | isUIntType ty1 && isIntType ty2 = True
-          | otherwise = ty1 == ty2
+      numericSubtypeOf sub super
+          | isIntType sub && isRealType super = True
+          | isIntType sub && isUIntType super = True
+          | isUIntType sub && isIntType super = True
+          | otherwise = sub == super
 
 assertSubtypeOf :: Type -> Type -> TypecheckM ()
 assertSubtypeOf sub super =


### PR DESCRIPTION
Instead of `ty1` and `ty2`, the arguments are called `sub` and
`super`. Intuitively, `subtypeOf sub super` is true if `sub` is a
subtype of `super`.