### PR TITLE
Add loop and initial design of prune combinator

### DIFF
--- a/modules/prototype/ParT/ParT.enc
+++ b/modules/prototype/ParT/ParT.enc
@@ -500,24 +500,83 @@ end
 -- loop :: Par[t] -> (t -> t') -> (t' -> bool) -> Par[t']
 --
 -- loops the items in the ParT until all items satisfy the exit condition.
--- it is assumed that the parametric argument `t` is not a val object, as it
--- prevents mutating its state. Ideally, it should be a `linear t`, but this
--- is left open until I can proof its usefulness. Beware of data races!
+-- NOTE:
+-- the parametric argument `t` should not be a val object nor a primitive type.
+-- If not, the function that returns a `t'` would never exist.
+-- Ideally, it should be a `linear t`, but this is left open until I can proof its usefulness.
 --
 fun loop[t, t'](p: Par[t], fn: t -> Par[t'], exitCondition: t' -> bool): Par[t']
-  bind(fun (x: t) => loopF(x, fn, exitCondition), p)
+  val tp = new TaskPool(4)
+  bind(fun (x: t) => loopF(x, fn, exitCondition, tp), p)
 end
 
 
 -- private function
-fun loopF[t, t'](item: t, fn: t -> Par[t'], exitCondition: t' -> bool): Par[t']
+fun loopF[t, t'](item: t,
+                 fn: t -> Par[t'],
+                 exitCondition: t' -> bool,
+                 pool: TaskPool): Par[t']
+  -- TODO: this looping design may actually create many Fut[Par[t]], which are
+  --       not the most efficient ParTs to deal with, because of the wrapping and
+  --       and unwrapping.
   bind(fun (x: t')
          if exitCondition(x) then
            liftv(x)
          else
-           join(liftf(async(loopF(item, fn, exitCondition))))
+           -- TODO: Evaluate alternative:
+           --   1. Task pool
+           join(liftf(pool.execute(fun () => loopF(item, fn, exitCondition, pool))))
+           --   2. Creation of a short-lived actor for each iteration
+           -- join(liftf(async(loopF(item, fn, exitCondition, pool))))
          end
        end, fn(item))
+end
+
+active class Worker
+  val id: uint
+
+  def init(id : uint) : unit
+    this.id = id
+  end
+
+  def start[sharable a](fn: () -> a): a
+    fn()
+  end
+end
+
+
+read class TaskPool
+  val numberWorkers : uint = 4
+  val workers : [Worker]
+  val index : uint = 0
+
+  def init(numberWorkers : uint): unit
+    this.numberWorkers = numberWorkers
+    this.workers = new [Worker](numberWorkers)
+    repeat i <- numberWorkers do
+      this.workers(i) = new Worker(i)
+    end
+  end
+
+  def execute[sharable t](fn: () -> t): Fut[t]
+    val index = EMBED (uint)
+                  uint64_t current = __atomic_load_n(&#{this.index}, __ATOMIC_RELAXED);
+                  uint64_t next = (current + 1) % #{this.numberWorkers};
+
+                  while (!__atomic_compare_exchange_n(&#{this.index},
+                                                      &current,
+                                                      next,
+                                                      false,
+                                                      __ATOMIC_RELAXED,
+                                                      __ATOMIC_RELAXED))
+                  {
+                    current = __atomic_load_n(&#{this.index}, __ATOMIC_RELAXED);
+                    next = (current + 1) % #{this.numberWorkers};
+                  }
+                  current;
+                END
+    this.workers(index)!start(fun () => fn())
+  end
 end
 
 -- local class MyObject

--- a/modules/prototype/ParT/ParT.enc
+++ b/modules/prototype/ParT/ParT.enc
@@ -492,7 +492,9 @@ end
 
 
 fun prune[t, t'](fn: Fut[Maybe[t]] -> Par[t'], p: Par[t]): Par[t']
-  empty[t']()
+  EMBED (Par[t'])
+    party_prune(_ctx, #{fn}, #{p}, _enc__type_t, _enc__t__type_t_prime);
+  END
 end
 
 
@@ -579,36 +581,36 @@ read class TaskPool
   end
 end
 
--- local class MyObject
---   var x : int
---   val id : int = 0
---   val infinite : bool = false
+local class MyObject
+  var x : int
+  val id : int = 0
+  val infinite : bool = false
 
---   def init(id: int, x: int): unit
---     this.id = id
---     this.x = x
---     if this.id == 1 then
---       this.infinite = true
---     end
---   end
+  def init(id: int, x: int): unit
+    this.id = id
+    this.x = x
+    if this.id == 1 then
+      this.infinite = true
+    end
+  end
 
--- end
+end
 
 
--- active class Main
---   def main(): unit
---     val p = liftv(new MyObject(0, 3)) ||| liftv(new MyObject(1, 0)) ||| liftv(new MyObject(2, -9)) ||| liftv(new MyObject(3, 4))
---     val pp = loop(p, fun (y: MyObject)
---                        y.x += 1
---                        liftv(y)
---                      end,
---                      fun (exit: MyObject) => exit.x >= 5)
---     pp >> fun (z : MyObject) => println(z.id)
---     val ppp = extract(pp)
+active class Main
+  def main(): unit
+    val p = liftv(new MyObject(0, 3)) ||| liftv(new MyObject(1, 0)) ||| liftv(new MyObject(2, -9)) ||| liftv(new MyObject(3, 4))
+    val pp = loop(p, fun (y: MyObject)
+                       y.x += 1
+                       liftv(y)
+                     end,
+                     fun (exit: MyObject) => exit.x >= 5)
+    pp >> fun (z : MyObject) => println(z.id)
+    val ppp = extract(pp)
 
---     println("Printing sorted solution")
---     for x <- ppp do
---       print("{}, ", x.id)
---     end
---   end
--- end
+    println("Printing sorted solution")
+    for x <- ppp do
+      print("{}, ", x.id)
+    end
+  end
+end

--- a/modules/prototype/ParT/ParT.enc
+++ b/modules/prototype/ParT/ParT.enc
@@ -581,36 +581,36 @@ read class TaskPool
   end
 end
 
-local class MyObject
-  var x : int
-  val id : int = 0
-  val infinite : bool = false
+-- local class MyObject
+--   var x : int
+--   val id : int = 0
+--   val infinite : bool = false
 
-  def init(id: int, x: int): unit
-    this.id = id
-    this.x = x
-    if this.id == 1 then
-      this.infinite = true
-    end
-  end
+--   def init(id: int, x: int): unit
+--     this.id = id
+--     this.x = x
+--     if this.id == 1 then
+--       this.infinite = true
+--     end
+--   end
 
-end
+-- end
 
 
-active class Main
-  def main(): unit
-    val p = liftv(new MyObject(0, 3)) ||| liftv(new MyObject(1, 0)) ||| liftv(new MyObject(2, -9)) ||| liftv(new MyObject(3, 4))
-    val pp = loop(p, fun (y: MyObject)
-                       y.x += 1
-                       liftv(y)
-                     end,
-                     fun (exit: MyObject) => exit.x >= 5)
-    pp >> fun (z : MyObject) => println(z.id)
-    val ppp = extract(pp)
+-- active class Main
+--   def main(): unit
+--     val p = liftv(new MyObject(0, 3)) ||| liftv(new MyObject(1, 0)) ||| liftv(new MyObject(2, -9)) ||| liftv(new MyObject(3, 4))
+--     val pp = loop(p, fun (y: MyObject)
+--                        y.x += 1
+--                        liftv(y)
+--                      end,
+--                      fun (exit: MyObject) => exit.x >= 5)
+--     pp >> fun (z : MyObject) => println(z.id)
+--     val ppp = extract(pp)
 
-    println("Printing sorted solution")
-    for x <- ppp do
-      print("{}, ", x.id)
-    end
-  end
-end
+--     println("Printing sorted solution")
+--     for x <- ppp do
+--       print("{}, ", x.id)
+--     end
+--   end
+-- end

--- a/modules/prototype/ParT/ParT.enc
+++ b/modules/prototype/ParT/ParT.enc
@@ -21,7 +21,11 @@ module ParT(
     any,
     max,
     min,
+    prune,
+    loop,
   )
+
+import Task
 
 --
 -- empty :: a -> Par[a]
@@ -485,3 +489,67 @@ fun each[t](arr: [t]): Par[t]
     new_par_array(_ctx, #{arr}, _enc__type_t);
   END
 end
+
+
+fun prune[t, t'](fn: Fut[Maybe[t]] -> Par[t'], p: Par[t]): Par[t']
+  empty[t']()
+end
+
+
+--
+-- loop :: Par[t] -> (t -> t') -> (t' -> bool) -> Par[t']
+--
+-- loops the items in the ParT until all items satisfy the exit condition.
+-- it is assumed that the parametric argument `t` is not a val object, as it
+-- prevents mutating its state. Ideally, it should be a `linear t`, but this
+-- is left open until I can proof its usefulness. Beware of data races!
+--
+fun loop[t, t'](p: Par[t], fn: t -> Par[t'], exitCondition: t' -> bool): Par[t']
+  bind(fun (x: t) => loopF(x, fn, exitCondition), p)
+end
+
+
+-- private function
+fun loopF[t, t'](item: t, fn: t -> Par[t'], exitCondition: t' -> bool): Par[t']
+  bind(fun (x: t')
+         if exitCondition(x) then
+           liftv(x)
+         else
+           join(liftf(async(loopF(item, fn, exitCondition))))
+         end
+       end, fn(item))
+end
+
+-- local class MyObject
+--   var x : int
+--   val id : int = 0
+--   val infinite : bool = false
+
+--   def init(id: int, x: int): unit
+--     this.id = id
+--     this.x = x
+--     if this.id == 1 then
+--       this.infinite = true
+--     end
+--   end
+
+-- end
+
+
+-- active class Main
+--   def main(): unit
+--     val p = liftv(new MyObject(0, 3)) ||| liftv(new MyObject(1, 0)) ||| liftv(new MyObject(2, -9)) ||| liftv(new MyObject(3, 4))
+--     val pp = loop(p, fun (y: MyObject)
+--                        y.x += 1
+--                        liftv(y)
+--                      end,
+--                      fun (exit: MyObject) => exit.x >= 5)
+--     pp >> fun (z : MyObject) => println(z.id)
+--     val ppp = extract(pp)
+
+--     println("Printing sorted solution")
+--     for x <- ppp do
+--       print("{}, ", x.id)
+--     end
+--   end
+-- end

--- a/modules/prototype/ParT/ParT.enc
+++ b/modules/prototype/ParT/ParT.enc
@@ -499,7 +499,7 @@ end
 
 
 --
--- loop :: Par[t] -> (t -> t') -> (t' -> bool) -> Par[t']
+-- loop :: Par[t] -> (t -> Par[t']) -> (t' -> bool) -> Par[t']
 --
 -- loops the items in the ParT until all items satisfy the exit condition.
 -- NOTE:
@@ -580,37 +580,3 @@ read class TaskPool
     this.workers(index)!start(fun () => fn())
   end
 end
-
--- local class MyObject
---   var x : int
---   val id : int = 0
---   val infinite : bool = false
-
---   def init(id: int, x: int): unit
---     this.id = id
---     this.x = x
---     if this.id == 1 then
---       this.infinite = true
---     end
---   end
-
--- end
-
-
--- active class Main
---   def main(): unit
---     val p = liftv(new MyObject(0, 3)) ||| liftv(new MyObject(1, 0)) ||| liftv(new MyObject(2, -9)) ||| liftv(new MyObject(3, 4))
---     val pp = loop(p, fun (y: MyObject)
---                        y.x += 1
---                        liftv(y)
---                      end,
---                      fun (exit: MyObject) => exit.x >= 5)
---     pp >> fun (z : MyObject) => println(z.id)
---     val ppp = extract(pp)
-
---     println("Printing sorted solution")
---     for x <- ppp do
---       print("{}, ", x.id)
---     end
---   end
--- end

--- a/src/runtime/party/party.c
+++ b/src/runtime/party/party.c
@@ -460,6 +460,7 @@ static inline size_t party_get_final_size(pony_ctx_t **ctx, par_t const * p)
         array_t* ar_p = party_get_array(p);
         size_t size_p = array_size(ar_p);
         i += size_p;
+        // TODO: shouldn't we pop now?
         break;
       }
       default: exit(-1);

--- a/src/runtime/party/party.c
+++ b/src/runtime/party/party.c
@@ -9,6 +9,7 @@
 #include "structure.h"
 #include "list.c"
 #include "set.h"
+#include "option.h"
 
 typedef struct fmap_s fmap_s;
 typedef par_t* (*fmapfn)(par_t*, fmap_s*);
@@ -968,4 +969,158 @@ par_t* party_zip_with(pony_ctx_t **ctx,
   list_t *lr = party_leaves_to_list(ctx, pr);
   par_t *result = party_zip_list(ctx, ll, lr, fn, type);
   return result;
+}
+
+struct env_stream_from_party {
+  future_t *promise;
+  par_t *par;
+  int counter;
+};
+
+static void trace_collect_from_stream_party(pony_ctx_t *_ctx, void *p)
+{
+  pony_ctx_t ** ctx = &_ctx;
+  struct env_stream_from_party *this = p;
+  encore_trace_object(*ctx, this->promise, future_trace);
+  encore_trace_object(*ctx, this->par, party_trace);
+}
+
+// TODO:
+static inline void selective_prune_party(__attribute__ ((unused)) pony_ctx_t **ctx,
+                                         __attribute__ ((unused)) par_t *p)
+{
+  (void)0;
+}
+
+// (noreturn) closure signature does not allow a not return
+static value_t
+stream_value_from_party(pony_ctx_t** ctx,
+                        pony_type_t** runtimeType,
+                        value_t args[],
+                        void* env) {
+  future_t *promise = ((struct env_stream_from_party*) env)->promise;
+
+  int prev_counter =
+      __atomic_fetch_sub(&((struct env_stream_from_party*) env)->counter,
+                         1,
+                         __ATOMIC_RELAXED);
+
+  if (prev_counter == 1) {
+    par_t *par = ((struct env_stream_from_party*) env)->par;
+
+    option_t *option = option_mk(ctx, JUST, args[0], *runtimeType);
+    future_fulfil(ctx,
+                  promise,
+                  (value_t) { .p = option});
+    selective_prune_party(ctx, par);
+  }
+  return (value_t) {.p = NULL};
+}
+
+//
+//  STREAM_ITEMS_FROM_PRUNE
+//
+// defines the number of streaming items that should be set in the future
+// gotten by prune, i.e. how many items does the future contains. prune
+// always fetches a single item from the Par[t] given as second argument.
+//
+//   (Fut[Maybe[t]] -> Par[t']) -> Par[t] -> Par[t']
+//
+//
+#define STREAM_ITEMS_FROM_PRUNE 1
+
+static inline void party_promise_prune(pony_ctx_t **ctx,
+                                       future_t *promise,
+                                       par_t *par,
+                                       pony_type_t *parType)
+{
+  // 1. Start iterating through ParT and attaching fulfilment of future
+  //    if an element of the ParT is fulfilled. only the first fulfilled item
+  //    in the ParT fulfils the promise.
+  //
+  //    basically:
+  //      1.1 attach a function call that fulfils the promise
+  //
+  // 2. if promise has been fulfilled, send pruning to original ParT
+  //
+
+  struct env_stream_from_party *env = encore_alloc(*ctx, sizeof(struct env_stream_from_party));
+  env->counter = STREAM_ITEMS_FROM_PRUNE;
+  env->promise = promise;
+  env->par = par;
+
+  closure_t *c = closure_mk(ctx, stream_value_from_party,
+                            env, trace_collect_from_stream_party, (pony_type_t* []) {parType});
+
+  // Iterate through items in the ParT.
+  // If future is found, then attach closure.
+  // If parT is found, traverse left and right until future or value is found.
+  // If value is found, make direct function call (no need for closure indirection)
+  //   and call on prune method on parT.
+  list_t *tmp_lst = NULL;
+  par_t *p = par;
+  while(p){
+    switch(p->tag){
+    case EMPTY_PAR: {
+      tmp_lst = list_pop(tmp_lst, (value_t*)&p);
+      break;
+    }
+    case VALUE_PAR: {
+      // the value needs to be wraped in an option type
+      closure_call(ctx, c, (value_t[]){ party_get_v(p) });
+      p = NULL; // break from while loop
+      break;
+    }
+    case FUTURE_PAR: {
+      // the value needs to be wrapper in an option type
+      future_register_callback(ctx, party_get_fut(p), c);
+      tmp_lst = list_pop(tmp_lst, (value_t*)&p);
+      break;
+    }
+    case PAR_PAR: {
+      par_t *left = party_get_parleft(p);
+      par_t *right = party_get_parright(p);
+      tmp_lst = list_push(tmp_lst, (value_t) { .p = right });
+      p = left;
+      break;
+    }
+    case FUTUREPAR_PAR: {
+      // TODO: this should not be an await, but a new closure attach to the ParT
+      //       which repeats the process when the Fut[Par[t]] is fulfilled.
+      future_t *futpar = party_get_futpar(p);
+      future_await(ctx, futpar);
+      p = future_get_actor(ctx, futpar).p;
+      break;
+    }
+    case ARRAY_PAR: {
+      array_t* arr = party_get_array(p);
+      if (array_size(arr) > 0) {
+        closure_call(ctx, c, (value_t[]) { array_get(arr, 0) } );
+        p = NULL; // break from while loop
+      } else {
+        tmp_lst = list_pop(tmp_lst, (value_t*)&p);
+      }
+      break;
+    }
+    default: exit(-1);
+    }
+  }
+}
+
+par_t* party_prune(pony_ctx_t **ctx,
+                   closure_t *fn,
+                   par_t *par,
+                   pony_type_t *parType,
+                   __attribute__ ((unused)) pony_type_t *returnedType)
+{
+  // this future is a promise, i.e. fulfilled by a function, not an actor.
+  // INFO: make sure the promise is fulfilled with an Maybe[t]
+  future_t *promise = future_mk(ctx, &option_type);
+
+  // this function needs to be asynchronous, non-blocking
+  // although iteration over things is ok as long as it doesn't block, i.e.
+  // await for a ParT item to finish.
+  party_promise_prune(ctx, promise, par, parType);
+
+  return closure_call(ctx, fn, (value_t[]) {[0] = {.p = promise }}).p;
 }

--- a/src/runtime/party/party.h
+++ b/src/runtime/party/party.h
@@ -166,4 +166,9 @@ par_t* party_zip_with(pony_ctx_t **ctx,
                       pony_type_t *type);
 
 
+par_t* party_prune(pony_ctx_t **ctx,
+                   closure_t *fn,
+                   par_t *par,
+                   pony_type_t *parType,
+                   pony_type_t *returnedType);
 #endif

--- a/src/tests/encore/par/loop.enc
+++ b/src/tests/encore/par/loop.enc
@@ -1,0 +1,104 @@
+import ParT.ParT
+
+EMBED
+#include<unistd.h>
+END
+
+local class MyObject
+  var x : int
+  val id : int = 0
+
+  def init(id: int, x: int): unit
+    this.id = id
+    this.x = x
+  end
+end
+
+read class Counter
+  val id: uint = 0
+  val x: uint = 0
+
+  def init(id: uint): unit
+    this.id = id
+  end
+
+  def inc(): uint
+    EMBED (uint)
+      // safely cheating to increment the counter
+      #{this.x} = #{this.x} + 1;
+    END
+  end
+end
+
+active class Delayer
+  val counter: Counter
+  val timer: uint
+
+  def init(timer: uint): unit
+    this.timer = timer
+    this.counter = new Counter(1)
+  end
+
+  def startDelay(): Counter
+    EMBED (unit)
+      sleep(#{this.timer});
+    END
+    this.counter
+  end
+end
+
+--
+-- Tests that the ParT does not block until all elements satisfy the test condition.
+-- Fulfilled items in the ParT are "streamed" to other combinators.
+--
+fun testStreamingElementsFromLoop(): unit
+  println("\n- Tests 'streaming' fulfilled elements from the loop:\n")
+  val p = liftv(new Counter(100)) ||| liftf((new Delayer(2))!startDelay())
+  val pp = loop(p, fun (y: Counter)
+                     y.inc()
+                     liftv(y)
+                   end,
+                   fun (exit: Counter) => exit.x >= 5)
+  prune(fun (f : Fut[Maybe[Counter]])
+          join(liftf(f ~~> fun (m : Maybe[Counter])
+                             match m with
+                               case Just(c) =>
+                                 do
+                                   println("\t* Streaming counter with id: {}", c.x)
+                                   liftv(c.x)
+                                 end
+                               end
+                             end
+                           end))
+        end, pp)
+  println("\t* Printing sorted solution")
+  val pp' = extract(pp)
+  for x <- pp' do
+    print("\t\t{}, ", x.id)
+  end
+end
+
+
+--
+-- Tests that the ParT loops until all elements satisfy the test condition
+--
+fun testLoopUntilExitCondition(): unit
+  println("\n- Tests looping until exit condition is met:\n")
+  val p = liftv(new MyObject(0, 3)) ||| liftv(new MyObject(1, 0)) ||| liftv(new MyObject(2, -9)) ||| liftv(new MyObject(3, 4))
+  val pp = loop(p, fun (y: MyObject)
+                     y.x += 1
+                     liftv(y)
+                   end,
+                   fun (exit: MyObject) => exit.x >= 5)
+  println("\tPrinting sorted solution")
+  for x <- extract(pp) do
+    print("\t{}, ", x.id)
+  end
+end
+
+active class Main
+  def main(): unit
+    testLoopUntilExitCondition()
+    testStreamingElementsFromLoop()
+  end
+end

--- a/src/tests/encore/par/loop.out
+++ b/src/tests/encore/par/loop.out
@@ -1,0 +1,10 @@
+
+- Tests looping until exit condition is met:
+
+	Printing sorted solution
+	0, 	1, 	2, 	3, 
+- Tests 'streaming' fulfilled elements from the loop:
+
+	* Streaming counter with id: 5
+	* Printing sorted solution
+		100, 		1, 

--- a/src/tests/encore/par/prune.enc
+++ b/src/tests/encore/par/prune.enc
@@ -1,0 +1,84 @@
+import ParT.ParT
+import Task
+
+read class MyObject
+  val id : int = 0
+
+  def init(id: int): unit
+    this.id = id
+  end
+
+  def value(): int
+    this.id
+  end
+
+  def inc(): uint
+    EMBED (uint)
+      // safely cheating to increment the counter
+      #{this.id} = #{this.id} + 1;
+    END
+  end
+end
+
+--
+-- Helper function
+--
+fun generateObjects(number: uint): Par[MyObject]
+  var p = empty[MyObject]()
+  for i <- [0..number] do
+    p = p ||| liftf(async(new MyObject(i)))
+  end
+  p
+end
+
+--
+-- TESTS
+--
+
+fun testOnlyOneItemGetsThrough(): unit
+  println("\n- Tests only one item gets through:\n")
+  val p = generateObjects(1000) >> fun (m : MyObject) => m.id
+  prune(fun (f : Fut[Maybe[int]])
+          join(liftf(f ~~> fun (m : Maybe[int])
+                             match m with
+                               case Just(i) =>
+                                 do
+                                   println("\t* Streaming counter with id: {}", i)
+                                   liftv(i)
+                                 end
+                               end
+                             end
+                           end))
+        end, p)
+end
+
+fun testLoopingAndPrune(): unit
+  println("\n- Tests looping and pruning (not cancelling operations):\n")
+  val p = generateObjects(1000)
+  val p' = loop(p, fun (c: MyObject)
+                     c.inc()
+                     liftv(c)
+                   end,
+                   fun (c: MyObject) => c.id >= 500)
+  extract(p')
+  prune(fun (f : Fut[Maybe[MyObject]])
+          join(liftf(f ~~> fun (m : Maybe[MyObject])
+                             match m with
+                               case Just(c) =>
+                                 do
+                                   println("\t* Streaming counter with id: {}", c.id)
+                                   liftv(c.id)
+                                 end
+                               end
+                             end
+                           end))
+        end, p')
+end
+
+active class Main
+  def main(): unit
+    testOnlyOneItemGetsThrough()
+
+    testLoopingAndPrune()
+  end
+end

--- a/src/tests/encore/par/prune.out
+++ b/src/tests/encore/par/prune.out
@@ -1,0 +1,8 @@
+
+- Tests only one item gets through:
+
+	* Streaming counter with id: 0
+
+- Tests looping and pruning (not cancelling operations):
+
+	* Streaming counter with id: 500


### PR DESCRIPTION
This PR adds the _loop_ combinator and the initial design of the _prune_ combinator (i.e. no killing yet).

- `loop :: Par[t] -> (t -> Par[t']) -> (t' -> bool) -> Par[t']` this combinator for performing useful computations until all elements in the ParT satisfy an exit condition. Elements that satisfy the exit condition do not need to continue iterating and can be asynchronously "streamed" to other ParT combinators. This combinator has been added based on experience from the SAT solver case study.

- `prune :: (Fut[Maybe[t]] -> Par[t']) -> Par[t]) -> Par[t']` this combinator puts in the future the first computation that finishes from the `Par[t]` (second argument). The function call is executed immediately, returning a new ParT (`Par[t']`). At the C level, the implementation uses a lock-free algorithm to ensure that only one item in the ParT fulfils the future. The killing part of remaining computations needs a bit more work and will be submitted in another PR. This should keep things simple and the review of the killing deserves its own PR (work-in-progress)

I have added tests to the _loop_ and _prune_ combinators. 