### PR TITLE
Fix #863: using clang as the default compiler for runtime

### DIFF
--- a/src/runtime/pony/premake4.lua
+++ b/src/runtime/pony/premake4.lua
@@ -25,6 +25,11 @@ if premake.override then
   end)
 end
 
+if os.execute("clang -v") == 0 then
+  premake.gcc.cc  = 'clang'
+  premake.gcc.cxx = 'clang++'
+end
+
 function use_flto()
   buildoptions {
     "-O3",


### PR DESCRIPTION
Currently, we use gcc for building the runtime, and clang for building
the final executable when `encorec` is invoked. However, using two
compilers is not only unnecessary but error-prone as well. 465 is another bug
related to using gcc, so let's use clang in the whole build stack from
now.