### PR TITLE
Ability to compile pony runtime with gcc 7.x

### DIFF
--- a/src/front/TopLevel.hs
+++ b/src/front/TopLevel.hs
@@ -243,7 +243,7 @@ compileProgram prog sourcePath options =
            customFlags = case find isCustomFlags options of
                            Just (CustomFlags str) -> str
                            Nothing                -> ""
-           flags = "-std=gnu11 -Wall -fms-extensions -Wno-format -Wno-microsoft -Wno-parentheses-equality -Wno-unused-variable -Wno-unused-value" <+> customFlags <+> "-lpthread -ldl -lm -Wno-attributes"
+           flags = "-std=gnu11 -Wall -fms-extensions -Wno-format -latomic -Wno-microsoft -Wno-parentheses-equality -Wno-unused-variable -Wno-unused-value" <+> customFlags <+> "-lpthread -ldl -lm -Wno-attributes"
            oFlag = "-o" <+> execName
            defines = getDefines options
            incs  = "-I" <+> incPath <+> "-I ."

--- a/src/runtime/pony/premake4.lua
+++ b/src/runtime/pony/premake4.lua
@@ -64,6 +64,7 @@ solution "ponyrt"
     buildoptions {
       "-mcx16",
       "-pthread",
+      "-latomic",
       "-std=gnu11",
       "-march=native",
       "-Wunused-parameter",


### PR DESCRIPTION
Make sure these boxes are checked before submitting your pull request:

- [✓] Description of the pull request stating the problem and the solution
- [ x ] Tests (if applicable)
- [ x ] Documentation (if applicable)

This is a solution to #863 
The ponyrt needs to be compiled with the flag -latomic as well as every encore project needs to be linked with said flag.

NOTE: This should be tested on multiple devices before acceptance
