### PR TITLE
Upgrade GHC from 7.10.3 to 8.0.2 with stackage LTS

### DIFF
--- a/encore.cabal
+++ b/encore.cabal
@@ -30,16 +30,16 @@ executable encorec
                   , CPP
                   , ScopedTypeVariables
   build-depends: MissingH
-               , base >=4.7 && <4.9
+               , base
                , containers >= 0.5.5.1
-               , directory >=1.2 && <1.3
+               , directory
                , hashable
                , hpc
                , mtl ==2.2.*
-               , megaparsec >= 5.1.2
+               , megaparsec >= 5.1.2 && < 5.2
                , semigroups
-               , pretty >=1.1 && <1.2
-               , process >=1.2 && <1.3
+               , pretty
+               , process
                , template-haskell
                , text >=1.1
                , ghc >= 7.10
@@ -48,5 +48,5 @@ executable encorec
                , boxes
                , filepath
   hs-source-dirs:      src/back src/front src/ir src/opt src/parser src/types
-  ghc-options: -Werror
+  ghc-options: -Werror -fmax-pmcheck-iterations=10000000
   default-language:    Haskell2010

--- a/src/types/Typechecker/Capturechecker.hs
+++ b/src/types/Typechecker/Capturechecker.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ConstrainedClassMethods #-}
 {-|
 
 Capturechecks an "AST.AST" and produces the same tree, extended

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,4 +4,4 @@ packages:
 - '.'
 extra-deps:
 - megaparsec-5.1.2
-resolver: lts-6.0
+resolver: lts-9.17


### PR DESCRIPTION
This commit upgrades `pretty` so that the upcoming error message feature
could be merged. The only "manual" change is in `stack.yaml`, while the
rest is instructed by the compiler, as trying to build the project.